### PR TITLE
Sanitize attachment names, restrict link schemes

### DIFF
--- a/src/message/attachment.rs
+++ b/src/message/attachment.rs
@@ -24,6 +24,8 @@ use super::message::TEMP_FOLDER;
 use crate::gio::prelude::*;
 use crate::{gio, glib};
 
+const DEFAULT_FILENAME: &str = "attachment";
+
 #[derive(Debug, Clone)]
 pub struct Attachment {
   pub filename: String,
@@ -33,13 +35,31 @@ pub struct Attachment {
 }
 
 impl Attachment {
+  /// The file name comes from the message, so it can contain anything, including
+  /// path separators and dot segments. gio::File::child() resolves those, so
+  /// writing to `filename` directly can escape the target directory.
+  pub fn safe_filename(&self) -> String {
+    let name = self
+      .filename
+      .rsplit(|c| c == '/' || c == '\\')
+      .next()
+      .unwrap_or("");
+    let name: String = name.chars().filter(|c| !c.is_control()).collect();
+    let name = name.trim();
+
+    if name.is_empty() || name == "." || name == ".." {
+      return DEFAULT_FILENAME.to_string();
+    }
+    name.to_string()
+  }
+
   pub async fn write_to_tmp(&self) -> Result<gio::File, Box<dyn Error>> {
     let tmp = gio::File::for_path(TEMP_FOLDER.to_str().unwrap());
     if file_exists(&tmp).await.is_ok_and(|v| !v) {
       log::debug!("create_dir({:?})", &tmp);
       tmp.make_directory_future(glib::Priority::default()).await?;
     }
-    let tmp = tmp.child(&self.filename);
+    let tmp = tmp.child(self.safe_filename());
     log::debug!("write_to_tmp({:?})", &tmp);
     self.write_to_file(&tmp).await?;
     Ok(tmp)
@@ -97,6 +117,47 @@ impl fmt::Display for Attachment {
       self.filename,
       self.mime_type.as_deref().unwrap_or("None")
     )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn attachment(filename: &str) -> Attachment {
+    Attachment {
+      filename: filename.to_string(),
+      content_id: String::new(),
+      body: vec![],
+      mime_type: None,
+    }
+  }
+
+  #[test]
+  fn safe_filename_keeps_regular_names() {
+    assert_eq!(attachment("Deus_Gnome.png").safe_filename(), "Deus_Gnome.png");
+    assert_eq!(attachment("état des lieux.pdf").safe_filename(), "état des lieux.pdf");
+  }
+
+  #[test]
+  fn safe_filename_strips_directories() {
+    assert_eq!(attachment("../../.bashrc").safe_filename(), ".bashrc");
+    assert_eq!(attachment("/etc/passwd").safe_filename(), "passwd");
+    assert_eq!(attachment("..\\..\\evil.exe").safe_filename(), "evil.exe");
+    assert_eq!(attachment("a/b/c.png").safe_filename(), "c.png");
+  }
+
+  #[test]
+  fn safe_filename_falls_back_when_nothing_is_left() {
+    assert_eq!(attachment("").safe_filename(), DEFAULT_FILENAME);
+    assert_eq!(attachment("..").safe_filename(), DEFAULT_FILENAME);
+    assert_eq!(attachment("/").safe_filename(), DEFAULT_FILENAME);
+    assert_eq!(attachment("evil/").safe_filename(), DEFAULT_FILENAME);
+  }
+
+  #[test]
+  fn safe_filename_strips_control_characters() {
+    assert_eq!(attachment("a\nb\tc.png").safe_filename(), "abc.png");
   }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,26 @@
 // Common utilities.
 use crate::glib;
 
+/// Returns the lowercased scheme of `uri`, or None if it has no valid one.
+/// A scheme is an ASCII letter followed by letters, digits, '+', '-' or '.'
+/// (RFC 3986).
+pub fn uri_scheme(uri: &str) -> Option<String> {
+  let scheme = uri.split(':').next()?;
+  if scheme.is_empty() || scheme.len() == uri.len() {
+    return None;
+  }
+
+  let mut chars = scheme.chars();
+  if !chars.next()?.is_ascii_alphabetic() {
+    return None;
+  }
+  if !chars.all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.') {
+    return None;
+  }
+
+  Some(scheme.to_ascii_lowercase())
+}
+
 pub fn spawn_and_wait<R: 'static, F: std::future::Future<Output = R> + 'static>(
   ctx: Option<&glib::MainContext>,
   f: F,
@@ -48,6 +68,25 @@ mod tests {
 
   use crate::utils::*;
   use crate::{gio, glib};
+
+  #[test]
+  fn uri_schemes() {
+    assert_eq!(uri_scheme("https://example.com").as_deref(), Some("https"));
+    assert_eq!(uri_scheme("HTTPS://example.com").as_deref(), Some("https"));
+    assert_eq!(
+      uri_scheme("mailto:john@moon.space").as_deref(),
+      Some("mailto")
+    );
+    assert_eq!(
+      uri_scheme("javascript:alert(1)").as_deref(),
+      Some("javascript")
+    );
+    assert_eq!(uri_scheme("file:///etc/passwd").as_deref(), Some("file"));
+    assert_eq!(uri_scheme(""), None);
+    assert_eq!(uri_scheme("no-scheme"), None);
+    assert_eq!(uri_scheme("://example.com"), None);
+    assert_eq!(uri_scheme("1http://example.com"), None);
+  }
 
   #[test]
   fn wait_for_no_result() {

--- a/src/window.rs
+++ b/src/window.rs
@@ -37,6 +37,10 @@ use crate::utils;
 
 const SETTINGS_SHOW_FILE_NAME: &str = "show-file-name";
 
+/// Links in a message are opened by the system handler, so only hand over the
+/// schemes a mail is expected to link to.
+const ALLOWED_URI_SCHEMES: [&str; 3] = ["http", "https", "mailto"];
+
 mod imp {
   use std::cell::{OnceCell, RefCell};
 
@@ -426,7 +430,7 @@ impl MailViewerWindow {
     let initial_file = current_file
       .parent()
       .unwrap()
-      .child(attachment.filename.as_str());
+      .child(attachment.safe_filename());
 
     let save_dialog = gtk4::FileDialog::builder()
       .title(&gettext("Save attachment..."))
@@ -502,10 +506,22 @@ impl MailViewerWindow {
               if uri.starts_with("about:") {
                 return Ok(false);
               }
+              // Decide before launching, so that a refused or failing uri is never
+              // loaded in the webview instead.
+              policy.ignore();
+
+              let allowed = utils::uri_scheme(uri.as_str())
+                .map_or(false, |scheme| ALLOWED_URI_SCHEMES.contains(&scheme.as_str()));
+              if !allowed {
+                log::warn!("WebView decide_policy(refused) => {}", uri);
+                return Ok(true);
+              }
+
               log::debug!("WebView decide_policy(launch) => {}", uri);
               if let Err(e) = gtk4::UriLauncher::new(&uri).launch_future(Some(self)).await {
                 return Err(format!("{} ({}): {}", &gettext("Failed to open uri"), &uri, e).into());
               }
+              return Ok(true);
             }
             policy.ignore();
             return Ok(true);


### PR DESCRIPTION
Two fixes for values that come straight from the message.

**Attachment file names.** `write_to_tmp()` passed the name to `gio::File::child()`, which resolves path separators and dot segments, so an attachment named `../../.bashrc` is written outside `$XDG_RUNTIME_DIR/mailviewer/<uuid>` — and `write_to_file()` replaces the destination. An absolute name trips `assertion '!g_path_is_absolute (name)' failed` in `g_file_get_child()`, which returns NULL and panics. Flatpak limits the damage (`home:ro`), builds from source don't. Only the base name is kept now.

**Links.** Every uri from `decide_policy()` went to `UriLauncher`, including `file://`, `javascript:` and `data:`, so a message could get the system handler to open anything. Only `http`, `https` and `mailto` are handed over now — `tel:` and `ftp:` used to work and no longer do, say the word if you want them back.

The policy is also decided before launching: on a refused or failing uri the decision was left unhandled and the webview navigated to it instead.

Tests cover the name sanitizing and the scheme parsing.
