### PR TITLE
Fix print shortcut, attachment overwrite, runtime dir and zoom

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -51,7 +51,7 @@ mod imp {
       obj.setup_gactions();
       obj.set_accels_for_action("app.quit", &["<primary>q"]);
       obj.set_accels_for_action("win.open-file-dialog", &["<primary>o"]);
-      obj.set_accels_for_action("win.print", &["<primary>o"]);
+      obj.set_accels_for_action("win.print", &["<primary>p"]);
       obj.set_accels_for_action("win.reset-zoom", &["<primary>r"]);
     }
   }

--- a/src/message/attachment.rs
+++ b/src/message/attachment.rs
@@ -66,18 +66,15 @@ impl Attachment {
   }
 
   pub async fn write_to_file(&self, file: &gio::File) -> Result<(), Box<dyn Error>> {
-    let io_stream = if file_exists(file).await.is_ok_and(|v| v) {
-      file
-        .open_readwrite_future(glib::Priority::default())
-        .await?
-    } else {
-      file
-        .create_readwrite_future(
-          gio::FileCreateFlags::REPLACE_DESTINATION,
-          glib::Priority::default(),
-        )
-        .await?
-    };
+    // replace_readwrite() truncates an existing file, open_readwrite() does not.
+    let io_stream = file
+      .replace_readwrite_future(
+        None,
+        false,
+        gio::FileCreateFlags::REPLACE_DESTINATION,
+        glib::Priority::default(),
+      )
+      .await?;
 
     let output_stream = io_stream.output_stream();
     let write_res = output_stream
@@ -123,6 +120,7 @@ impl fmt::Display for Attachment {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::utils;
 
   fn attachment(filename: &str) -> Attachment {
     Attachment {
@@ -131,6 +129,26 @@ mod tests {
       body: vec![],
       mime_type: None,
     }
+  }
+
+  #[test]
+  fn write_to_file_replaces_the_previous_content() {
+    let path = std::env::temp_dir().join(format!(
+      "mailviewer-write-to-file-{}.bin",
+      std::process::id()
+    ));
+    std::fs::write(&path, b"AAAAAAAAAAAAAAAA").unwrap();
+
+    let file = gio::File::for_path(&path);
+    let mut attachment = attachment("small.bin");
+    attachment.body = b"BBBB".to_vec();
+
+    utils::spawn_and_wait_new_ctx(async move {
+      attachment.write_to_file(&file).await.unwrap();
+    });
+
+    assert_eq!(std::fs::read(&path).unwrap(), b"BBBB".to_vec());
+    std::fs::remove_file(&path).unwrap();
   }
 
   #[test]

--- a/src/message/message.rs
+++ b/src/message/message.rs
@@ -37,7 +37,9 @@ const MSG_MIME_TYPES: [&str; 2] = ["application/vnd.ms-outlook", "application/x-
 
 lazy_static! {
   pub static ref TEMP_FOLDER: PathBuf = {
-    let mut path = PathBuf::from(std::env::var("XDG_RUNTIME_DIR").unwrap());
+    // XDG_RUNTIME_DIR is not always set (ssh sessions, containers), glib then
+    // falls back to the user cache directory, which is user owned too.
+    let mut path = glib::user_runtime_dir();
     let uuid = Uuid::new_v4().simple().to_string();
     path.push(APP_NAME);
     if !path.exists() {

--- a/src/window.rs
+++ b/src/window.rs
@@ -41,6 +41,10 @@ const SETTINGS_SHOW_FILE_NAME: &str = "show-file-name";
 /// schemes a mail is expected to link to.
 const ALLOWED_URI_SCHEMES: [&str; 3] = ["http", "https", "mailto"];
 
+const ZOOM_STEP: f64 = 0.1;
+const ZOOM_MIN: f64 = 0.3;
+const ZOOM_MAX: f64 = 5.0;
+
 mod imp {
   use std::cell::{OnceCell, RefCell};
 
@@ -240,13 +244,13 @@ impl MailViewerWindow {
   #[template_callback]
   pub fn on_zoom_minus_clicked(&self) {
     log::debug!("on_zoom_minus_clicked()");
-    self.set_zoom_level(self.imp().webview.zoom_level() - 0.1);
+    self.set_zoom_level(self.imp().webview.zoom_level() - ZOOM_STEP);
   }
 
   #[template_callback]
   pub fn on_zoom_plus_clicked(&self) {
     log::debug!("on_zoom_plus_clicked()");
-    self.set_zoom_level(self.imp().webview.zoom_level() + 0.1);
+    self.set_zoom_level(self.imp().webview.zoom_level() + ZOOM_STEP);
   }
 
   fn initialize(&self) {
@@ -320,7 +324,9 @@ impl MailViewerWindow {
     let imp = self.imp();
 
     imp.settings.set(settings.clone()).unwrap();
-    imp.webview.set_zoom_level(settings.get::<f64>("zoom"));
+    imp
+      .webview
+      .set_zoom_level(settings.get::<f64>("zoom").clamp(ZOOM_MIN, ZOOM_MAX));
 
     settings
       .bind("width", self, "default-width")
@@ -476,6 +482,7 @@ impl MailViewerWindow {
   }
 
   fn set_zoom_level(&self, zoom: f64) {
+    let zoom = zoom.clamp(ZOOM_MIN, ZOOM_MAX);
     log::debug!("set_zoom({})", zoom);
     self.imp().webview.set_zoom_level(zoom);
     if let Some(settings) = self.imp().settings.get() {


### PR DESCRIPTION
Four unrelated fixes, one per commit.

- **Ctrl+P for print.** `win.print` and `win.open-file-dialog` were both bound to `<primary>o`, so print had no reachable shortcut.
- **Saving an attachment over an existing file.** `write_to_file()` used `open_readwrite()` when the destination existed, which does not truncate: saving a 4 KB attachment over a 40 KB file left 36 KB of the old content behind. `replace_readwrite()` truncates, and the exists check goes away with its race. Test included.
- **`XDG_RUNTIME_DIR` unwrapped.** It is not always set — ssh sessions, a tty, minimal containers — and the application aborted on the first attachment. `glib::user_runtime_dir()` falls back to the user cache directory, which is user owned too.
- **Zoom bounds.** Zooming out repeatedly reached 0, and the level is persisted, so the next start showed an empty page. Clamped to 0.3–5, including the value read from the settings so an already stored 0 recovers.
