### PR TITLE
Run the test suite on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: test
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+
+jobs:
+  test:
+    name: "cargo test"
+    runs-on: ubuntu-24.04
+
+    # gtk 4.22 and libadwaita 1.9 are not in the runner image, so run in a
+    # container that has them.
+    container:
+      image: ubuntu:26.04
+
+    steps:
+      - name: install dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+            build-essential ca-certificates cargo git gtk-update-icon-cache \
+            libadwaita-1-dev libgmime-3.0-dev libwebkitgtk-6.0-dev pkg-config rustc
+
+      - uses: actions/checkout@v6
+
+      - name: cargo test
+        run: cargo test

--- a/build.rs
+++ b/build.rs
@@ -94,9 +94,13 @@ fn icons(cfg: &Config) {
     println!("cargo:warning=gtk4-update-icon-cache => {:?}", _output);
     exit(5);
   }
+  // XDG_DATA_DIRS is unset in a bare environment (containers, CI), the spec
+  // default applies then.
+  let data_dirs =
+    env::var("XDG_DATA_DIRS").unwrap_or_else(|_| "/usr/local/share:/usr/share".to_string());
   println!(
     "cargo:rustc-env=XDG_DATA_DIRS={}:{}",
-    env::var("XDG_DATA_DIRS").unwrap(),
+    data_dirs,
     cfg.out_dir.to_str().unwrap()
   );
 }

--- a/src/message/attachment.rs
+++ b/src/message/attachment.rs
@@ -113,6 +113,26 @@ impl fmt::Display for Attachment {
   }
 }
 
+async fn file_exists(file: &gio::File) -> Result<bool, Box<dyn Error>> {
+  match file
+    .query_info_future(
+      gio::FILE_ATTRIBUTE_STANDARD_NAME,
+      gio::FileQueryInfoFlags::NONE,
+      glib::Priority::default(),
+    )
+    .await
+  {
+    Ok(_) => Ok(true),
+    Err(e) => {
+      if !e.matches(gio::IOErrorEnum::NotFound) {
+        return Err(Box::new(e));
+      }
+
+      Ok(false)
+    }
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -178,25 +198,5 @@ mod tests {
   #[test]
   fn safe_filename_strips_control_characters() {
     assert_eq!(attachment("a\nb\tc.png").safe_filename(), "abc.png");
-  }
-}
-
-async fn file_exists(file: &gio::File) -> Result<bool, Box<dyn Error>> {
-  match file
-    .query_info_future(
-      gio::FILE_ATTRIBUTE_STANDARD_NAME,
-      gio::FileQueryInfoFlags::NONE,
-      glib::Priority::default(),
-    )
-    .await
-  {
-    Ok(_) => Ok(true),
-    Err(e) => {
-      if !e.matches(gio::IOErrorEnum::NotFound) {
-        return Err(Box::new(e));
-      }
-
-      Ok(false)
-    }
   }
 }

--- a/src/message/electronicmail.rs
+++ b/src/message/electronicmail.rs
@@ -266,13 +266,6 @@ impl ElectronicMail {
   }
 }
 
-impl Drop for ElectronicMail {
-  fn drop(&mut self) {
-    log::debug!("Drop ElectronicMail()");
-    MessageParser::cleanup();
-  }
-}
-
 impl super::message::Message for ElectronicMail {
   fn parse(&mut self, cancellable: Option<&gio::Cancellable>) -> Result<(), Box<dyn Error>> {
     let stream = StreamMem::with_buffer(&self.data);

--- a/src/message/message.rs
+++ b/src/message/message.rs
@@ -205,13 +205,6 @@ impl MessageParser {
   }
 }
 
-impl Drop for MessageParser {
-  fn drop(&mut self) {
-    log::debug!("MessageParser::drop()");
-    Self::cleanup();
-  }
-}
-
 impl Message for MessageParser {
   fn parse(&mut self, cancellable: Option<&gio::Cancellable>) -> Result<(), Box<dyn Error>> {
     self.parser.parse(cancellable)

--- a/src/message/outlook.rs
+++ b/src/message/outlook.rs
@@ -161,13 +161,6 @@ impl Message for OutlookMessage {
   }
 }
 
-impl Drop for OutlookMessage {
-  fn drop(&mut self) {
-    log::warn!("OutlookMessage::drop()");
-    MessageParser::cleanup();
-  }
-}
-
 #[cfg(test)]
 mod tests {
   use std::error::Error;


### PR DESCRIPTION
The workflows only built the flatpak bundle, so the tests never ran anywhere but on a developer machine. Two things had to be fixed before they could.

- **`build.rs` unwrapped `XDG_DATA_DIRS`**, which is unset in a bare environment, so the build failed in a container before reaching the tests. It falls back to the XDG spec default now.
- **The suite failed about 60% of the runs.** `MessageParser`, `ElectronicMail` and `OutlookMessage` each removed the whole temporary folder on drop, and that folder is shared by the process, so one test deleted the attachment another had just written. The same bug hits the application: loading another message deletes the attachment an external viewer still has open. `main()` already cleans up on exit and the folder name is unique per process, so dropping those three `Drop` impls is enough. 8 consecutive green runs afterwards, against 3 failures in 5 before.

The job runs in an `ubuntu:26.04` container because the runner image has gtk 4.14 and the project needs 4.22. `rustc` and `cargo` come from apt (1.93.1), no third-party actions. I skipped the `ubuntu-26.04` runner since it is still marked preview.

Last commit moves the test module in `attachment.rs` to the end of the file: clippy warns about items after a test module, and I left it that way in #35.
