### PR TITLE
Fix non-utf-8 file names, markup in attachment rows and a print leak

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -93,11 +93,9 @@ mod imp {
         log::debug!("[ARGUMENT] File: {:?}, Hint : {:?}", file.path(), hint);
       }
 
-      if !files.is_empty() {
-        if let Some(path) = files[0].path() {
-          let path = path.to_str().unwrap().to_string();
-          self.filename.replace(Some(path.clone()));
-        }
+      // A path is not necessarily valid utf-8, the uri always is.
+      if let Some(file) = files.first() {
+        self.filename.replace(Some(file.uri().to_string()));
       }
       self.activate();
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -394,9 +394,12 @@ impl MailViewerWindow {
         ));
       }
     ));
+    // The file name and the mime type come from the message, don't let them
+    // through as pango markup.
     let btn = adw::ActionRow::builder()
       .title(attachment.filename.to_string())
       .subtitle(mime)
+      .use_markup(false)
       .activatable(true)
       .build();
     btn.add_prefix(&gtk4::Image::from_icon_name(icon));

--- a/src/window.rs
+++ b/src/window.rs
@@ -95,6 +95,7 @@ mod imp {
     pub settings: OnceCell<gio::Settings>,
     pub service: MailService,
     pub cancellable: RefCell<gio::Cancellable>,
+    pub print_webview: RefCell<Option<webkit6::WebView>>,
   }
 
   impl Default for MailViewerWindow {
@@ -122,6 +123,7 @@ mod imp {
         settings: OnceCell::new(),
         service: MailService::new(),
         cancellable: RefCell::new(gio::Cancellable::new()),
+        print_webview: RefCell::new(None),
       }
     }
   }
@@ -677,25 +679,30 @@ impl MailViewerWindow {
     let websettings = webkit6::Settings::new();
     let html: String = self.get_print_html();
     self.initialise_webview(&webview, &websettings);
-    webview.load_html(&html, None);
+
+    // The view has to stay alive until it has loaded, but holding it in its own
+    // signal handler makes a reference cycle and neither the view nor its web
+    // process are ever freed. Hold it here and let go once printing is done.
+    self.imp().print_webview.replace(Some(webview.clone()));
+
     webview.connect_load_changed(clone!(
-      #[strong(rename_to = window)]
+      #[weak(rename_to = window)]
       self,
-      #[strong]
-      webview,
-      move |_, e| {
+      move |webview, e| {
         log::debug!("print load_html() event : {:?}", e);
         if e == webkit6::LoadEvent::Finished {
-          let print_operation = PrintOperation::new(&webview);
+          let print_operation = PrintOperation::new(webview);
           let response = print_operation.run_dialog(Some(&window));
           if response == PrintOperationResponse::Print {
             log::debug!("print started");
           } else {
             log::debug!("print cancelled");
           }
+          window.imp().print_webview.replace(None);
         }
       }
     ));
+    webview.load_html(&html, None);
   }
 
   pub async fn open_file_dialog(&self, close_on_cancel: bool) -> bool {


### PR DESCRIPTION
Three unrelated fixes, one per commit.

- **Crash on file names that are not valid utf-8.** `open()` did `path.to_str().unwrap()`, so opening such a file from GNOME Files aborted the application: `panicked at src/application.rs:98: called Option::unwrap() on a None value`. Reproduced with a file whose name carries a raw `0xE1` byte, opened through `org.freedesktop.Application.Open` the way the file manager does. The uri is always valid utf-8 and `win.open-file` already accepts one, so that is what gets stored now, and the same file opens and renders fine.
- **Attachment names rendered as pango markup.** `AdwPreferencesRow` uses markup for its title by default, and the row shows the file name and the mime type straight from the message, so `invoice<b>.pdf` renders as markup and can hide what the file really is.
- **A leaked web view per print.** The view was captured strongly in its own `load-changed` handler, and the view owns the handler: a reference cycle, so neither it nor its web process were ever freed. The window holds it while it loads and drops it when the dialog closes.

`cargo test`, `cargo clippy --all-targets` and `cargo +nightly fmt --check` are clean.
