### PR TITLE
Stop a message from reaching the network behind the toggle

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -30,9 +30,21 @@ pub const CSS: &str = r#"
 </style>
 "#;
 
+/// Removing tags is not enough to keep a message offline : css can reach the
+/// network on its own through @import, @font-face and url(). A policy is
+/// enforced by the engine, so it covers what the sanitizer cannot see.
+/// data: stays allowed, it is what inline (cid) images are rewritten to.
+const CSP_BLOCK_REMOTE: &str =
+  "default-src 'none'; style-src 'unsafe-inline'; img-src data:; media-src data:";
+
+const CSP_ALLOW_REMOTE: &str = "default-src 'none'; style-src 'unsafe-inline' http: https:; \
+                                img-src data: http: https:; font-src http: https:; \
+                                media-src data: http: https:";
+
 pub struct Html {
   body: String,
   strip_css: bool,
+  allow_remote: bool,
 }
 
 impl Html {
@@ -40,7 +52,15 @@ impl Html {
     Self {
       body: body.to_string(),
       strip_css,
+      allow_remote: false,
     }
+  }
+
+  /// Whether the message may pull content from the network, i.e. the state of
+  /// the "Show remote images" button.
+  pub fn allow_remote(mut self, allow_remote: bool) -> Self {
+    self.allow_remote = allow_remote;
+    self
   }
 
   pub fn escape(value: &str) -> String {
@@ -68,7 +88,12 @@ impl Html {
         .first()
         .append_html(CSS);
     }
-    document.html().to_string()
+    let policy = if self.allow_remote {
+      CSP_ALLOW_REMOTE
+    } else {
+      CSP_BLOCK_REMOTE
+    };
+    insert_csp(&document.html(), policy)
   }
 
   fn parse(&self, root: &Node) {
@@ -101,6 +126,22 @@ impl Html {
   }
 }
 
+/// Puts the policy right after the opening `<head>`, so that nothing declared
+/// in the message is parsed before it.
+fn insert_csp(html: &str, policy: &str) -> String {
+  let meta = format!(
+    "<meta http-equiv=\"Content-Security-Policy\" content=\"{}\">",
+    policy
+  );
+  if let Some(start) = html.find("<head") {
+    if let Some(end) = html[start..].find('>') {
+      let at = start + end + 1;
+      return format!("{}{}{}", &html[..at], meta, &html[at..]);
+    }
+  }
+  format!("{meta}{html}")
+}
+
 #[cfg(test)]
 mod tests {
   use std::error::Error;
@@ -119,7 +160,9 @@ mod tests {
     assert!(!body.contains("class="));
 
     assert!(!body.contains("<script"));
-    assert!(!body.contains("<meta"));
+    // every meta of the message is gone, the only one left is our own policy
+    assert_eq!(body.matches("<meta").count(), 1);
+    assert!(body.contains("<meta http-equiv=\"content-security-policy\""));
     assert!(!body.contains("<audio"));
     assert!(!body.contains("<video"));
     assert!(!body.contains("<iframe"));
@@ -132,5 +175,48 @@ mod tests {
     assert!(body.contains(&crate::html::CSS.to_lowercase()));
 
     Ok(())
+  }
+
+  #[test]
+  fn csp_is_the_first_thing_in_the_head() {
+    let body = crate::html::Html::new("<p>hello</p>", false).safe();
+    let head = body.find("<head>").expect("a head is always serialized");
+
+    assert!(body[head..].starts_with(
+      "<head><meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none';"
+    ));
+  }
+
+  #[test]
+  fn csp_blocks_remote_content_by_default() {
+    let body = crate::html::Html::new("<p>hello</p>", false).safe();
+
+    assert!(body.contains("img-src data:;"));
+    assert!(!body.contains("img-src data: http:"));
+    assert!(!body.contains("font-src"));
+  }
+
+  #[test]
+  fn csp_opens_up_when_remote_content_is_allowed() {
+    let body = crate::html::Html::new("<p>hello</p>", false)
+      .allow_remote(true)
+      .safe();
+
+    assert!(body.contains("img-src data: http: https:;"));
+    assert!(body.contains("font-src http: https:;"));
+  }
+
+  #[test]
+  fn csp_survives_a_message_that_brings_its_own_head() {
+    let body = crate::html::Html::new(
+      "<html><head><style>@import url(http://tracker/x.css);</style></head><body>hi</body></html>",
+      false,
+    )
+    .safe();
+    let head = body.find("<head>").unwrap();
+    let meta = body.find("Content-Security-Policy").unwrap();
+    let style = body.find("<style>").unwrap();
+
+    assert!(head < meta && meta < style, "the policy must come first");
   }
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -93,7 +93,15 @@ impl Html {
     } else {
       CSP_BLOCK_REMOTE
     };
-    insert_csp(&document.html(), policy)
+    // As a node, not by editing the serialized html : an attribute of the head
+    // can carry a '>' and swallow the tag.
+    let mut head = document.select("head");
+    let content = head.html();
+    head.set_html(format!(
+      "<meta http-equiv=\"Content-Security-Policy\" content=\"{policy}\">{content}"
+    ));
+
+    document.html().to_string()
   }
 
   fn parse(&self, root: &Node) {
@@ -124,22 +132,6 @@ impl Html {
       && s.as_bytes()[0].eq_ignore_ascii_case(&b'o')
       && s.as_bytes()[1].eq_ignore_ascii_case(&b'n')
   }
-}
-
-/// Puts the policy right after the opening `<head>`, so that nothing declared
-/// in the message is parsed before it.
-fn insert_csp(html: &str, policy: &str) -> String {
-  let meta = format!(
-    "<meta http-equiv=\"Content-Security-Policy\" content=\"{}\">",
-    policy
-  );
-  if let Some(start) = html.find("<head") {
-    if let Some(end) = html[start..].find('>') {
-      let at = start + end + 1;
-      return format!("{}{}{}", &html[..at], meta, &html[at..]);
-    }
-  }
-  format!("{meta}{html}")
 }
 
 #[cfg(test)]
@@ -204,6 +196,22 @@ mod tests {
 
     assert!(body.contains("img-src data: http: https:;"));
     assert!(body.contains("font-src http: https:;"));
+  }
+
+  #[test]
+  fn csp_is_not_swallowed_by_an_attribute_of_the_head() {
+    // A '>' inside an attribute of the head used to end the tag as far as a
+    // textual insertion was concerned, and the meta landed in the attribute.
+    let body = crate::html::Html::new(
+      "<html><head title=\">\"><style>@import url(http://tracker/x.css);</style></head><body>hi</body></html>",
+      false,
+    )
+    .safe();
+
+    assert!(
+      body.contains("<head title=\">\"><meta http-equiv=\"Content-Security-Policy\""),
+      "the policy must be an element of the head, not part of an attribute: {body}"
+    );
   }
 
   #[test]

--- a/src/window.rs
+++ b/src/window.rs
@@ -247,6 +247,8 @@ impl MailViewerWindow {
     let show = self.imp().show_images.is_active();
     log::debug!("on_show_images_clicked({})", show);
     self.imp().websettings.set_auto_load_images(show);
+    // The policy travels with the html, so the message has to be rendered again.
+    self.load_html(self.imp().force_css.is_active());
   }
 
   #[template_callback]
@@ -501,13 +503,21 @@ impl MailViewerWindow {
     }
   }
 
+  /// Sanitizes the body of the message, allowing remote content only while the
+  /// "Show remote images" button is on.
+  fn sanitized_html(&self, html: &str, force_css: bool) -> String {
+    Html::new(html, force_css)
+      .allow_remote(self.imp().show_images.is_active())
+      .safe()
+  }
+
   fn load_html(&self, force_css: bool) {
     log::debug!("load_html({})", force_css);
     let html = self.imp().service.body_html().unwrap_or_default();
     self
       .imp()
       .webview
-      .load_html(&Html::new(&html, force_css).safe(), None);
+      .load_html(&self.sanitized_html(&html, force_css), None);
   }
 
   async fn decide_policy(
@@ -615,7 +625,7 @@ impl MailViewerWindow {
     let content: String;
 
     if let Some(html) = imp.service.body_html() {
-      content = Html::new(&html, false).safe();
+      content = self.sanitized_html(&html, false);
     } else if let Some(text) = imp.service.body_text() {
       content = format!("<pre>{}</pre>", Html::escape(&text));
     } else {
@@ -782,7 +792,9 @@ impl MailViewerWindow {
     }
 
     if let Some(html) = imp.service.body_html() {
-      imp.webview.load_html(&Html::new(&html, false).safe(), None);
+      imp
+        .webview
+        .load_html(&self.sanitized_html(&html, false), None);
       has_html = true;
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -90,6 +90,7 @@ mod imp {
     pub attachments_clamp: TemplateChild<adw::Clamp>,
     //
     pub scrolled_window: ScrolledWindow,
+    pub network_session: webkit6::NetworkSession,
     pub webview: webkit6::WebView,
     pub websettings: webkit6::Settings,
     pub settings: OnceCell<gio::Settings>,
@@ -100,8 +101,13 @@ mod imp {
 
   impl Default for MailViewerWindow {
     fn default() -> Self {
+      // Nothing a message pulls in has any business surviving on disk, so keep
+      // the cache and the cookies of the session in memory only.
+      let network_session = webkit6::NetworkSession::new_ephemeral();
+
       MailViewerWindow {
-        webview: WebView::new(),
+        webview: WebView::builder().network_session(&network_session).build(),
+        network_session,
         websettings: webkit6::Settings::new(),
         scrolled_window: ScrolledWindow::new(),
         from: TemplateChild::default(),
@@ -661,7 +667,9 @@ impl MailViewerWindow {
   pub async fn print(&self) {
     log::debug!("print()");
 
-    let webview = webkit6::WebView::new();
+    let webview = WebView::builder()
+      .network_session(&self.imp().network_session)
+      .build();
     let websettings = webkit6::Settings::new();
     let html: String = self.get_print_html();
     self.initialise_webview(&webview, &websettings);

--- a/src/window.rs
+++ b/src/window.rs
@@ -619,21 +619,7 @@ impl MailViewerWindow {
     let date = Html::escape(imp.service.date().as_str());
     let to = Html::escape(imp.service.to().as_str());
     let subject = Html::escape(imp.service.subject().as_str());
-    let attachments = imp
-      .service
-      .attachments()
-      .iter()
-      .map(|attachment| {
-        let filename = Html::escape(&attachment.filename);
-        if let Some(mime_type) = attachment.mime_type.as_deref() {
-          if !mime_type.is_empty() {
-            return format!("<li>{filename} ({mime_type})</li>");
-          }
-        }
-        format!("<li>{filename}</li>")
-      })
-      .collect::<Vec<_>>()
-      .join("\n");
+    let attachments = print_attachment_list(&imp.service.attachments());
 
     format!(
       r#"<!doctype html>
@@ -890,5 +876,57 @@ impl MailViewerWindow {
         );
       }
     }
+  }
+}
+
+/// The `<li>` list of attachments for the printed page. Both the file name and
+/// the mime type come from the message, so both are escaped.
+fn print_attachment_list(attachments: &[Attachment]) -> String {
+  attachments
+    .iter()
+    .map(|attachment| {
+      let filename = Html::escape(&attachment.filename);
+      match attachment.mime_type.as_deref() {
+        Some(mime_type) if !mime_type.is_empty() => {
+          format!("<li>{filename} ({})</li>", Html::escape(mime_type))
+        }
+        _ => format!("<li>{filename}</li>"),
+      }
+    })
+    .collect::<Vec<_>>()
+    .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn attachment(filename: &str, mime_type: Option<&str>) -> Attachment {
+    Attachment {
+      filename: filename.to_string(),
+      content_id: String::new(),
+      body: vec![],
+      mime_type: mime_type.map(String::from),
+    }
+  }
+
+  #[test]
+  fn print_attachment_list_escapes_both_fields() {
+    let list = print_attachment_list(&[
+      attachment("Deus_Gnome.png", Some("image/png")),
+      attachment("a&b<c>.txt", Some("text/plain")),
+      attachment("report.pdf", Some("application/pdf\"><img src=x>")),
+      attachment("no-mime.bin", None),
+      attachment("empty-mime.bin", Some("")),
+    ]);
+
+    assert_eq!(
+      list,
+      "<li>Deus_Gnome.png (image/png)</li>\n\
+       <li>a&amp;b&lt;c&gt;.txt (text/plain)</li>\n\
+       <li>report.pdf (application/pdf&quot;&gt;&lt;img src=x&gt;)</li>\n\
+       <li>no-mime.bin</li>\n\
+       <li>empty-mime.bin</li>"
+    );
   }
 }


### PR DESCRIPTION
Three fixes around remote content, one per commit.

- **`@import` and `@font-face` ignored "Show remote images".** `auto-load-images` only covers images, and the sanitizer only removes tags. With the button off, a message containing

  ```html
  <style>@import url(http://tracker/x.css);</style>
  <style>@font-face { src: url(http://tracker/f.woff2) }</style>
  ```

  still made both requests against a local server, which tells the sender the message was opened. A content security policy is added as the first thing in the head, so nothing is fetched before it is parsed, and the engine enforces it, which also covers what the sanitizer cannot see. `data:` stays allowed, that is what inline (cid) images are rewritten to. Zero requests after the change. Turning the button on renders the message again with a policy that allows http and https — it did not reload before, so turning it on had no effect until another message was opened.
- **What a message loaded was written to disk.** The view used the default network session, so fetching that stylesheet left `~/.cache/mailviewer/WebKitCache/` and an `HSTS/hsts-storage.sqlite` behind. An ephemeral session keeps it in memory; nothing on disk afterwards. The print view shares the session.
- **The mime type was not escaped when printing.** The file name was, the mime type next to it was not, and it comes from the `Content-Type` of the message.

`cargo test` (42), `cargo clippy --all-targets -- -D warnings` and `cargo +nightly fmt --check` are clean.
