### PR TITLE
Translate the file error, give print a mnemonic and a shortcut entry

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-16 14:15+0200\n"
+"POT-Creation-Date: 2026-08-18 11:18+0200\n"
 "PO-Revision-Date: 2026-08-12 22:15+0200\n"
 "Last-Translator: Ángel Guzmán Maeso <angel@guzmanmaeso.com>\n"
 "Language-Team: Spanish <LL@li.org>\n"
@@ -69,48 +69,69 @@ msgid "Alexandre Del Bigio"
 msgstr "Alexandre Del Bigio"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:50
-msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgid ""
+"Fix non-utf-8 file names, markup in attachment rows and a print leak "
+"(shakaran)"
 msgstr ""
+"Se corrigen los nombres de archivo que no son UTF-8, el markup en las filas "
+"de adjuntos y una fuga al imprimir (gracias a shakaran)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:51
-msgid "Spanish translation (thanks to shakaran)"
-msgstr ""
+msgid "Improve temporary file cleanup (shakaran)"
+msgstr "Se mejora la limpieza de los archivos temporales (shakaran)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:58
+msgid ""
+"Fix print shortcut, attachment overwrite, runtime dir and zoom (thanks to "
+"shakaran)"
+msgstr ""
+"Se corrigen el atajo de impresión, la sobrescritura de adjuntos, el "
+"directorio de ejecución y el zoom (gracias a shakaran)"
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:59
+msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgstr ""
+"Se sanean los nombres de los adjuntos y se restringen los esquemas de los "
+"enlaces (gracias a shakaran)"
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:60
+msgid "Spanish translation (thanks to shakaran)"
+msgstr "Traducción al español (gracias a shakaran)"
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:67
 msgid "Display local time with UTC offset"
 msgstr "Se muestra la hora local con el desfase UTC"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:65
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
 msgid "Better print support (escape HTML when printing text)"
 msgstr ""
 "Mejor compatibilidad con la impresión (se escapa el HTML al imprimir texto)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:66
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:75
 msgid "Outlook (msg) don't show text button if text field is empty"
 msgstr ""
-"Outlook (msg): no se muestra el botón de texto si el campo de texto está "
-"vacío"
+"Outlook (msg): no se muestra el botón de texto si el campo de texto está vacío"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:73
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:82
 msgid "Sync \"Show remote images\" status for html print"
 msgstr ""
 "Se sincroniza el estado de «Mostrar imágenes remotas» al imprimir en HTML"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:83
 msgid "Outlook (msg) now support HTML"
 msgstr "Outlook (msg) ya admite HTML"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:81
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:90
 msgid "Feature : Print (in menu)"
 msgstr "Función: impresión (en el menú)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:88
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:97
 msgid "Bug : revert changes (stdin) preventing opening from GNOME Files"
 msgstr ""
 "Error: se revierten los cambios (stdin) que impedían abrir archivos desde "
 "Archivos de GNOME"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:95
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
 msgid ""
 "Test is data present on stdin if no file is provided (eg: cat sample.eml | "
 "mailviewer)"
@@ -118,181 +139,180 @@ msgstr ""
 "Se comprueba si hay datos en la entrada estándar cuando no se indica ningún "
 "archivo (p. ej.: cat sample.eml | mailviewer)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:102
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
 msgid "GitHub Actions rewrite (alescdb)"
 msgstr "Reescritura de GitHub Actions (alescdb)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:103
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
 msgid "Use an encoding library to properly decode the contents (3v1n0)"
 msgstr ""
 "Se usa una biblioteca de codificación para decodificar correctamente el "
 "contenido (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
 msgid "Handle Windows-1252 encoding (3v1n0)"
 msgstr "Se admite la codificación Windows-1252 (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:105
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
 msgid "Log parsing errors as errors (3v1n0)"
 msgstr "Los errores de análisis se registran como errores (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:106
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
 msgid "Use utils::span-and-wait to wait for web policy (3v1n0)"
 msgstr "Se usa utils::span-and-wait para esperar a la política web (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:107
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
 msgid "Expose spawn_and_wait to a generic utility crate (3v1n0)"
 msgstr "Se expone spawn_and_wait en un crate de utilidades genérico (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:108
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
 msgid "Stop parsing early if action is cancelled (3v1n0)"
 msgstr "El análisis se detiene antes si se cancela la acción (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:109
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
 msgid "Cancel previous loading operation using Cancellable (3v1n0)"
 msgstr "Se cancela la carga anterior mediante Cancellable (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:110
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
 msgid "Add test utility function to wait for futures to complete (3v1n0)"
 msgstr ""
-"Se añade una función de prueba para esperar a que terminen los futuros "
-"(3v1n0)"
+"Se añade una función de prueba para esperar a que terminen los futuros (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
 msgid "Add x-ole-storage as supported mime type (3v1n0)"
 msgstr "Se añade x-ole-storage como tipo MIME admitido (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
 msgid "Show a spinner while loading a message (3v1n0)"
 msgstr ""
 "Se muestra un indicador de actividad mientras se carga un mensaje (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
 msgid "Run the messages parsing in a separate thread (3v1n0)"
 msgstr "El análisis de los mensajes se ejecuta en un hilo aparte (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
 msgid "Bind visibility of action buttons to show text state (3v1n0)"
 msgstr ""
 "La visibilidad de los botones de acción se vincula al estado de «mostrar "
 "texto» (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
 msgid "Use gtk native future to open URIs / launch files (3v1n0)"
 msgstr ""
 "Se usan los futuros nativos de GTK para abrir URI o lanzar archivos (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
 msgid "Write the attachments on disk asynchronously (3v1n0)"
 msgstr "Los adjuntos se escriben en el disco de forma asíncrona (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:126
 msgid "Use better API to spawn futures from glib (3v1n0)"
 msgstr "Se usa una API mejor para lanzar futuros desde glib (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:127
 msgid "Use async loading of the files contents (3v1n0)"
 msgstr "El contenido de los archivos se carga de forma asíncrona (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:128
 msgid "Check file asynchronously and based on content type (3v1n0)"
 msgstr ""
 "Los archivos se comprueban de forma asíncrona y según su tipo de contenido "
 "(3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:129
 msgid "it, fr translations: Update Plural forms definitions (3v1n0)"
 msgstr ""
 "Traducciones al italiano y al francés: se actualizan las definiciones de las "
 "formas de plural (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:130
 msgid "Updated Dutch translation (Vistaus)"
 msgstr "Traducción al neerlandés actualizada (Vistaus)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:131
 msgid "Pre-set the file name when saving an attachment (3v1n0)"
 msgstr "Se propone el nombre del archivo al guardar un adjunto (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
 msgid "Use gtk4::FileDialog to open and save files (3v1n0)"
 msgstr "Se usa gtk4::FileDialog para abrir y guardar archivos (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
 msgid "Use ngettext to translate plural forms (3v1n0)"
 msgstr "Se usa ngettext para traducir las formas de plural (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:134
 msgid "Bump msg_parser to 0.1.2 (3v1n0)"
 msgstr "Se actualiza msg_parser a la versión 0.1.2 (3v1n0)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:141
 msgid "GNOME 49 (libadwaita 1.8)"
 msgstr "GNOME 49 (libadwaita 1.8)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:142
 msgid "Other dependencies updated"
 msgstr "Otras dependencias actualizadas"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:140
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:149
 msgid "Italian translation by albanobattistella"
 msgstr "Traducción al italiano por albanobattistella"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:147
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:156
 msgid "Gnome 48 (libadwaita 1.7)"
 msgstr "GNOME 48 (libadwaita 1.7)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:154
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:163
 msgid "Dependency Updates"
 msgstr "Actualización de dependencias"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:161
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
 msgid "Case insensitive file extensions"
 msgstr "Las extensiones de archivo no distinguen mayúsculas de minúsculas"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:167
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:176
 msgid "Add I18N support"
 msgstr "Se añade compatibilidad con la internacionalización (I18N)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:169
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:178
 msgid "French (fr_FR) by Me :-)"
 msgstr "Francés (fr_FR) por mí :-)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:179
 msgid "Dutch (nl) by Heimen Stoffels"
 msgstr "Neerlandés (nl) por Heimen Stoffels"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:177
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:186
 msgid "Add drag and drop support (file must have .eml or .msg extension)"
 msgstr ""
 "Se añade la posibilidad de arrastrar y soltar (el archivo debe tener la "
 "extensión .eml o .msg)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:184
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:193
 msgid "Correct a crash when .msg has no attachments"
 msgstr "Se corrige un fallo cuando el .msg no tiene adjuntos"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:191
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:200
 msgid "Add support for Outlook .msg"
 msgstr "Se añade compatibilidad con los .msg de Outlook"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:198
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
 msgid "Fix flatpak version"
 msgstr "Se corrige la versión de flatpak"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:199
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:208
 msgid "Fix gmime-rs date memory problem"
 msgstr "Se corrige un problema de memoria con las fechas de gmime-rs"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:206
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:215
 msgid "Fix attachment adding up"
 msgstr "Se corrige la acumulación de adjuntos"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:216
 msgid "Fix gmime randomly crashing"
 msgstr "Se corrigen los fallos aleatorios de gmime"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:213
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:222
 msgid "First flatpak release"
 msgstr "Primera versión en flatpak"
 
@@ -308,15 +328,20 @@ msgstr "Abrir archivo"
 
 #: src/gtk/help-overlay.ui:20
 msgctxt "shortcut window"
+msgid "Print File"
+msgstr "Imprimir archivo"
+
+#: src/gtk/help-overlay.ui:26
+msgctxt "shortcut window"
 msgid "Reset Zoom"
 msgstr "Restablecer el zoom"
 
-#: src/gtk/help-overlay.ui:26
+#: src/gtk/help-overlay.ui:32
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
 msgstr "Mostrar los atajos"
 
-#: src/gtk/help-overlay.ui:32
+#: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Salir"
@@ -394,8 +419,8 @@ msgid "_Open..."
 msgstr "_Abrir…"
 
 #: src/window.ui:260
-msgid "Print..."
-msgstr "Imprimir…"
+msgid "Pr_int..."
+msgstr "_Imprimir…"
 
 #: src/window.ui:264
 msgid "_Preferences"
@@ -413,54 +438,53 @@ msgstr "Atajos de _teclado"
 msgid "_About MailViewer"
 msgstr "Acerca _de MailViewer"
 
-#: src/window.rs:373
+#: src/window.rs:391
 msgid "Save as..."
 msgstr "Guardar como…"
 
-#: src/window.rs:435
+#: src/window.rs:456
 msgid "Save attachment..."
 msgstr "Guardar el adjunto…"
 
-#: src/window.rs:449 src/window.rs:747
+#: src/window.rs:470 src/window.rs:773
 msgid "File Error"
 msgstr "Error de archivo"
 
-#: src/window.rs:521
-msgid "Failed to open uri"
-msgstr "No se pudo abrir el URI"
-
-#: src/window.rs:578
-msgid "Mail Files"
-msgstr "Archivos de correo"
-
-#: src/window.rs:694
-msgid "Open Mail File"
-msgstr "Abrir un archivo de correo"
-
-#: src/window.rs:748
+#: src/window.rs:492 src/window.rs:774
 msgid "Failed to open file"
 msgstr "No se pudo abrir el archivo"
 
-#: src/window.rs:794
-#, rust-format
+#: src/window.rs:564
+msgid "Failed to open uri"
+msgstr "No se pudo abrir el URI"
+
+#: src/window.rs:621
+msgid "Mail Files"
+msgstr "Archivos de correo"
+
+#: src/window.rs:720
+msgid "Open Mail File"
+msgstr "Abrir un archivo de correo"
+
+#: src/window.rs:822
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} adjunto"
 msgstr[1] "{total} adjuntos"
 
 #. never shown
-#: src/window.rs:804
+#: src/window.rs:832
 msgid "No attachments"
 msgstr "Sin adjuntos"
 
-#: src/window.rs:818
+#: src/window.rs:846
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/window.rs:870
+#: src/window.rs:898
 msgid "Settings"
 msgstr "Configuración"
 
-#: src/window.rs:871
+#: src/window.rs:899
 msgid "Failed to get settings"
 msgstr "No se pudo obtener la configuración"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-16 14:15+0200\n"
+"POT-Creation-Date: 2026-08-18 11:18+0200\n"
 "PO-Revision-Date: 2024-11-14 17:23+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -76,208 +76,224 @@ msgid "Alexandre Del Bigio"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:50
-msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgid ""
+"Fix non-utf-8 file names, markup in attachment rows and a print leak "
+"(shakaran)"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:51
-msgid "Spanish translation (thanks to shakaran)"
+msgid "Improve temporary file cleanup (shakaran)"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:58
+msgid ""
+"Fix print shortcut, attachment overwrite, runtime dir and zoom (thanks to "
+"shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:59
+msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:60
+msgid "Spanish translation (thanks to shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:67
 msgid "Display local time with UTC offset"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:65
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
 msgid "Better print support (escape HTML when printing text)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:66
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:75
 msgid "Outlook (msg) don't show text button if text field is empty"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:73
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:82
 msgid "Sync \"Show remote images\" status for html print"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:83
 msgid "Outlook (msg) now support HTML"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:81
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:90
 msgid "Feature : Print (in menu)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:88
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:97
 msgid "Bug : revert changes (stdin) preventing opening from GNOME Files"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:95
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
 msgid ""
 "Test is data present on stdin if no file is provided (eg: cat sample.eml | "
 "mailviewer)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:102
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
 msgid "GitHub Actions rewrite (alescdb)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:103
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
 msgid "Use an encoding library to properly decode the contents (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
 msgid "Handle Windows-1252 encoding (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:105
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
 msgid "Log parsing errors as errors (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:106
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
 msgid "Use utils::span-and-wait to wait for web policy (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:107
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
 msgid "Expose spawn_and_wait to a generic utility crate (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:108
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
 msgid "Stop parsing early if action is cancelled (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:109
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
 msgid "Cancel previous loading operation using Cancellable (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:110
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
 msgid "Add test utility function to wait for futures to complete (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
 msgid "Add x-ole-storage as supported mime type (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
 msgid "Show a spinner while loading a message (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
 msgid "Run the messages parsing in a separate thread (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
 msgid "Bind visibility of action buttons to show text state (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
 msgid "Use gtk native future to open URIs / launch files (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
 msgid "Write the attachments on disk asynchronously (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:126
 msgid "Use better API to spawn futures from glib (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:127
 msgid "Use async loading of the files contents (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:128
 msgid "Check file asynchronously and based on content type (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:129
 msgid "it, fr translations: Update Plural forms definitions (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:130
 msgid "Updated Dutch translation (Vistaus)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:131
 msgid "Pre-set the file name when saving an attachment (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
 msgid "Use gtk4::FileDialog to open and save files (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
 msgid "Use ngettext to translate plural forms (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:134
 msgid "Bump msg_parser to 0.1.2 (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:141
 msgid "GNOME 49 (libadwaita 1.8)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:142
 msgid "Other dependencies updated"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:140
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:149
 msgid "Italian translation by albanobattistella"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:147
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:156
 msgid "Gnome 48 (libadwaita 1.7)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:154
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:163
 msgid "Dependency Updates"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:161
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
 msgid "Case insensitive file extensions"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:167
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:176
 msgid "Add I18N support"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:169
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:178
 msgid "French (fr_FR) by Me :-)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:179
 msgid "Dutch (nl) by Heimen Stoffels"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:177
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:186
 msgid "Add drag and drop support (file must have .eml or .msg extension)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:184
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:193
 msgid "Correct a crash when .msg has no attachments"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:191
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:200
 msgid "Add support for Outlook .msg"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:198
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
 msgid "Fix flatpak version"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:199
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:208
 msgid "Fix gmime-rs date memory problem"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:206
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:215
 msgid "Fix attachment adding up"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:216
 msgid "Fix gmime randomly crashing"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:213
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:222
 msgid "First flatpak release"
 msgstr ""
 
@@ -293,15 +309,20 @@ msgstr "Ouvrir un fichier"
 
 #: src/gtk/help-overlay.ui:20
 msgctxt "shortcut window"
+msgid "Print File"
+msgstr "Imprimer un fichier"
+
+#: src/gtk/help-overlay.ui:26
+msgctxt "shortcut window"
 msgid "Reset Zoom"
 msgstr "Réinitialiser le zoom"
 
-#: src/gtk/help-overlay.ui:26
+#: src/gtk/help-overlay.ui:32
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
 msgstr "Afficher les raccourcis"
 
-#: src/gtk/help-overlay.ui:32
+#: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Quitter"
@@ -379,8 +400,8 @@ msgid "_Open..."
 msgstr "_Ouvrir..."
 
 #: src/window.ui:260
-msgid "Print..."
-msgstr ""
+msgid "Pr_int..."
+msgstr "_Imprimer..."
 
 #: src/window.ui:264
 msgid "_Preferences"
@@ -398,57 +419,56 @@ msgstr "Raccourcis clavier"
 msgid "_About MailViewer"
 msgstr "_A propos de MailViewer"
 
-#: src/window.rs:373
+#: src/window.rs:391
 msgid "Save as..."
 msgstr "Enregister sous..."
 
-#: src/window.rs:435
+#: src/window.rs:456
 msgid "Save attachment..."
 msgstr "Enregister le fichier attaché..."
 
-#: src/window.rs:449 src/window.rs:747
+#: src/window.rs:470 src/window.rs:773
 msgid "File Error"
 msgstr "Erreur de fichier"
 
-#: src/window.rs:521
+#: src/window.rs:492 src/window.rs:774
+msgid "Failed to open file"
+msgstr "Impossible d'ouvrir le fichier"
+
+#: src/window.rs:564
 #, fuzzy
 msgid "Failed to open uri"
 msgstr "Impossible d'ouvrir le fichier"
 
-#: src/window.rs:578
+#: src/window.rs:621
 #, fuzzy
 msgid "Mail Files"
 msgstr "Ouvrir un fichier"
 
-#: src/window.rs:694
+#: src/window.rs:720
 msgid "Open Mail File"
 msgstr "Ouvrir un fichier"
 
-#: src/window.rs:748
-msgid "Failed to open file"
-msgstr "Impossible d'ouvrir le fichier"
-
-#: src/window.rs:794
-#, rust-format
+#: src/window.rs:822
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} fichier attaché"
 msgstr[1] "{total} fichiers attachés"
 
 #. never shown
-#: src/window.rs:804
+#: src/window.rs:832
 msgid "No attachments"
 msgstr "Aucun fichier attaché"
 
-#: src/window.rs:818
+#: src/window.rs:846
 msgid "Close"
 msgstr "Fermer"
 
-#: src/window.rs:870
+#: src/window.rs:898
 msgid "Settings"
 msgstr "Préférences"
 
-#: src/window.rs:871
+#: src/window.rs:899
 msgid "Failed to get settings"
 msgstr "Impossible de trouver les préférences"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-16 14:15+0200\n"
+"POT-Creation-Date: 2026-08-18 11:18+0200\n"
 "PO-Revision-Date: 2025-05-07 22:22+0100\n"
 "Last-Translator: Albano Battistella <albanobattistella@gmail.com>\n"
 "Language-Team: Italian <LL@li.org>\n"
@@ -69,210 +69,226 @@ msgid "Alexandre Del Bigio"
 msgstr "Alexandre Del Bigio"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:50
-msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgid ""
+"Fix non-utf-8 file names, markup in attachment rows and a print leak "
+"(shakaran)"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:51
-msgid "Spanish translation (thanks to shakaran)"
+msgid "Improve temporary file cleanup (shakaran)"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:58
+msgid ""
+"Fix print shortcut, attachment overwrite, runtime dir and zoom (thanks to "
+"shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:59
+msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:60
+msgid "Spanish translation (thanks to shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:67
 msgid "Display local time with UTC offset"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:65
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
 msgid "Better print support (escape HTML when printing text)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:66
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:75
 msgid "Outlook (msg) don't show text button if text field is empty"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:73
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:82
 msgid "Sync \"Show remote images\" status for html print"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:83
 msgid "Outlook (msg) now support HTML"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:81
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:90
 msgid "Feature : Print (in menu)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:88
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:97
 msgid "Bug : revert changes (stdin) preventing opening from GNOME Files"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:95
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
 msgid ""
 "Test is data present on stdin if no file is provided (eg: cat sample.eml | "
 "mailviewer)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:102
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
 msgid "GitHub Actions rewrite (alescdb)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:103
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
 msgid "Use an encoding library to properly decode the contents (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
 msgid "Handle Windows-1252 encoding (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:105
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
 msgid "Log parsing errors as errors (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:106
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
 msgid "Use utils::span-and-wait to wait for web policy (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:107
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
 msgid "Expose spawn_and_wait to a generic utility crate (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:108
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
 msgid "Stop parsing early if action is cancelled (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:109
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
 msgid "Cancel previous loading operation using Cancellable (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:110
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
 msgid "Add test utility function to wait for futures to complete (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
 msgid "Add x-ole-storage as supported mime type (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
 msgid "Show a spinner while loading a message (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
 msgid "Run the messages parsing in a separate thread (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
 msgid "Bind visibility of action buttons to show text state (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
 msgid "Use gtk native future to open URIs / launch files (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
 msgid "Write the attachments on disk asynchronously (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:126
 msgid "Use better API to spawn futures from glib (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:127
 msgid "Use async loading of the files contents (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:128
 msgid "Check file asynchronously and based on content type (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:129
 msgid "it, fr translations: Update Plural forms definitions (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:130
 msgid "Updated Dutch translation (Vistaus)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:131
 msgid "Pre-set the file name when saving an attachment (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
 msgid "Use gtk4::FileDialog to open and save files (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
 msgid "Use ngettext to translate plural forms (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:134
 msgid "Bump msg_parser to 0.1.2 (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:141
 msgid "GNOME 49 (libadwaita 1.8)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:142
 msgid "Other dependencies updated"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:140
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:149
 msgid "Italian translation by albanobattistella"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:147
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:156
 msgid "Gnome 48 (libadwaita 1.7)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:154
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:163
 msgid "Dependency Updates"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:161
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
 msgid "Case insensitive file extensions"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:167
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:176
 msgid "Add I18N support"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:169
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:178
 msgid "French (fr_FR) by Me :-)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:179
 msgid "Dutch (nl) by Heimen Stoffels"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:177
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:186
 msgid "Add drag and drop support (file must have .eml or .msg extension)"
 msgstr ""
 "Aggiunto il supporto drag-and-drop (il file deve avere estensione .eml "
 "o .msg)"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:184
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:193
 msgid "Correct a crash when .msg has no attachments"
 msgstr "Corretto un crash quando il file .msg non ha allegati"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:191
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:200
 msgid "Add support for Outlook .msg"
 msgstr "Aggiunto supporto per Outlook .msg"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:198
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
 msgid "Fix flatpak version"
 msgstr "Corretto la versione flatpak"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:199
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:208
 msgid "Fix gmime-rs date memory problem"
 msgstr "Risolto il problema della memoria della data di gmime-rs"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:206
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:215
 msgid "Fix attachment adding up"
 msgstr "Risolto il problema relativo all'aggiunta degli allegati"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:216
 msgid "Fix gmime randomly crashing"
 msgstr "Risolto il crash casuale di gmime"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:213
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:222
 msgid "First flatpak release"
 msgstr "Prima versione flatpak"
 
@@ -288,15 +304,20 @@ msgstr "Apri file"
 
 #: src/gtk/help-overlay.ui:20
 msgctxt "shortcut window"
+msgid "Print File"
+msgstr "Stampa file"
+
+#: src/gtk/help-overlay.ui:26
+msgctxt "shortcut window"
 msgid "Reset Zoom"
 msgstr "Reimposta zoom"
 
-#: src/gtk/help-overlay.ui:26
+#: src/gtk/help-overlay.ui:32
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
 msgstr "Mostra scorciatoie"
 
-#: src/gtk/help-overlay.ui:32
+#: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Esci"
@@ -374,8 +395,8 @@ msgid "_Open..."
 msgstr "_Apri..."
 
 #: src/window.ui:260
-msgid "Print..."
-msgstr ""
+msgid "Pr_int..."
+msgstr "S_tampa..."
 
 #: src/window.ui:264
 msgid "_Preferences"
@@ -393,57 +414,56 @@ msgstr "_Scorciatoie da tastiera"
 msgid "_About MailViewer"
 msgstr "_Informazioni su MailViewer"
 
-#: src/window.rs:373
+#: src/window.rs:391
 msgid "Save as..."
 msgstr "Salva con nome..."
 
-#: src/window.rs:435
+#: src/window.rs:456
 msgid "Save attachment..."
 msgstr "Salva allegato..."
 
-#: src/window.rs:449 src/window.rs:747
+#: src/window.rs:470 src/window.rs:773
 msgid "File Error"
 msgstr "Errore file"
 
-#: src/window.rs:521
+#: src/window.rs:492 src/window.rs:774
+msgid "Failed to open file"
+msgstr "Impossibile aprire il file"
+
+#: src/window.rs:564
 #, fuzzy
 msgid "Failed to open uri"
 msgstr "Impossibile aprire il file"
 
-#: src/window.rs:578
+#: src/window.rs:621
 #, fuzzy
 msgid "Mail Files"
 msgstr "Apri file di posta"
 
-#: src/window.rs:694
+#: src/window.rs:720
 msgid "Open Mail File"
 msgstr "Apri file di posta"
 
-#: src/window.rs:748
-msgid "Failed to open file"
-msgstr "Impossibile aprire il file"
-
-#: src/window.rs:794
-#, rust-format
+#: src/window.rs:822
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} allegato"
 msgstr[1] "{total} allegati"
 
 #. never shown
-#: src/window.rs:804
+#: src/window.rs:832
 msgid "No attachments"
 msgstr "Nessun allegato"
 
-#: src/window.rs:818
+#: src/window.rs:846
 msgid "Close"
 msgstr "Chiudi"
 
-#: src/window.rs:870
+#: src/window.rs:898
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/window.rs:871
+#: src/window.rs:899
 msgid "Failed to get settings"
 msgstr "Impossibile ottenere le impostazioni"
 

--- a/po/mailviewer.pot
+++ b/po/mailviewer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-16 14:15+0200\n"
+"POT-Creation-Date: 2026-08-18 11:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -65,208 +65,224 @@ msgid "Alexandre Del Bigio"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:50
-msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgid ""
+"Fix non-utf-8 file names, markup in attachment rows and a print leak "
+"(shakaran)"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:51
-msgid "Spanish translation (thanks to shakaran)"
+msgid "Improve temporary file cleanup (shakaran)"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:58
+msgid ""
+"Fix print shortcut, attachment overwrite, runtime dir and zoom (thanks to "
+"shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:59
+msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:60
+msgid "Spanish translation (thanks to shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:67
 msgid "Display local time with UTC offset"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:65
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
 msgid "Better print support (escape HTML when printing text)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:66
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:75
 msgid "Outlook (msg) don't show text button if text field is empty"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:73
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:82
 msgid "Sync \"Show remote images\" status for html print"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:83
 msgid "Outlook (msg) now support HTML"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:81
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:90
 msgid "Feature : Print (in menu)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:88
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:97
 msgid "Bug : revert changes (stdin) preventing opening from GNOME Files"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:95
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
 msgid ""
 "Test is data present on stdin if no file is provided (eg: cat sample.eml | "
 "mailviewer)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:102
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
 msgid "GitHub Actions rewrite (alescdb)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:103
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
 msgid "Use an encoding library to properly decode the contents (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
 msgid "Handle Windows-1252 encoding (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:105
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
 msgid "Log parsing errors as errors (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:106
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
 msgid "Use utils::span-and-wait to wait for web policy (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:107
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
 msgid "Expose spawn_and_wait to a generic utility crate (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:108
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
 msgid "Stop parsing early if action is cancelled (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:109
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
 msgid "Cancel previous loading operation using Cancellable (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:110
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
 msgid "Add test utility function to wait for futures to complete (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
 msgid "Add x-ole-storage as supported mime type (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
 msgid "Show a spinner while loading a message (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
 msgid "Run the messages parsing in a separate thread (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
 msgid "Bind visibility of action buttons to show text state (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
 msgid "Use gtk native future to open URIs / launch files (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
 msgid "Write the attachments on disk asynchronously (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:126
 msgid "Use better API to spawn futures from glib (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:127
 msgid "Use async loading of the files contents (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:128
 msgid "Check file asynchronously and based on content type (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:129
 msgid "it, fr translations: Update Plural forms definitions (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:130
 msgid "Updated Dutch translation (Vistaus)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:131
 msgid "Pre-set the file name when saving an attachment (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
 msgid "Use gtk4::FileDialog to open and save files (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
 msgid "Use ngettext to translate plural forms (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:134
 msgid "Bump msg_parser to 0.1.2 (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:141
 msgid "GNOME 49 (libadwaita 1.8)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:142
 msgid "Other dependencies updated"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:140
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:149
 msgid "Italian translation by albanobattistella"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:147
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:156
 msgid "Gnome 48 (libadwaita 1.7)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:154
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:163
 msgid "Dependency Updates"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:161
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
 msgid "Case insensitive file extensions"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:167
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:176
 msgid "Add I18N support"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:169
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:178
 msgid "French (fr_FR) by Me :-)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:179
 msgid "Dutch (nl) by Heimen Stoffels"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:177
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:186
 msgid "Add drag and drop support (file must have .eml or .msg extension)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:184
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:193
 msgid "Correct a crash when .msg has no attachments"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:191
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:200
 msgid "Add support for Outlook .msg"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:198
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
 msgid "Fix flatpak version"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:199
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:208
 msgid "Fix gmime-rs date memory problem"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:206
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:215
 msgid "Fix attachment adding up"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:216
 msgid "Fix gmime randomly crashing"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:213
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:222
 msgid "First flatpak release"
 msgstr ""
 
@@ -282,15 +298,20 @@ msgstr ""
 
 #: src/gtk/help-overlay.ui:20
 msgctxt "shortcut window"
-msgid "Reset Zoom"
+msgid "Print File"
 msgstr ""
 
 #: src/gtk/help-overlay.ui:26
 msgctxt "shortcut window"
-msgid "Show Shortcuts"
+msgid "Reset Zoom"
 msgstr ""
 
 #: src/gtk/help-overlay.ui:32
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr ""
+
+#: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr ""
@@ -368,7 +389,7 @@ msgid "_Open..."
 msgstr ""
 
 #: src/window.ui:260
-msgid "Print..."
+msgid "Pr_int..."
 msgstr ""
 
 #: src/window.ui:264
@@ -387,54 +408,53 @@ msgstr ""
 msgid "_About MailViewer"
 msgstr ""
 
-#: src/window.rs:373
+#: src/window.rs:391
 msgid "Save as..."
 msgstr ""
 
-#: src/window.rs:435
+#: src/window.rs:456
 msgid "Save attachment..."
 msgstr ""
 
-#: src/window.rs:449 src/window.rs:747
+#: src/window.rs:470 src/window.rs:773
 msgid "File Error"
 msgstr ""
 
-#: src/window.rs:521
-msgid "Failed to open uri"
-msgstr ""
-
-#: src/window.rs:578
-msgid "Mail Files"
-msgstr ""
-
-#: src/window.rs:694
-msgid "Open Mail File"
-msgstr ""
-
-#: src/window.rs:748
+#: src/window.rs:492 src/window.rs:774
 msgid "Failed to open file"
 msgstr ""
 
-#: src/window.rs:794
-#, rust-format
+#: src/window.rs:564
+msgid "Failed to open uri"
+msgstr ""
+
+#: src/window.rs:621
+msgid "Mail Files"
+msgstr ""
+
+#: src/window.rs:720
+msgid "Open Mail File"
+msgstr ""
+
+#: src/window.rs:822
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] ""
 msgstr[1] ""
 
 #. never shown
-#: src/window.rs:804
+#: src/window.rs:832
 msgid "No attachments"
 msgstr ""
 
-#: src/window.rs:818
+#: src/window.rs:846
 msgid "Close"
 msgstr ""
 
-#: src/window.rs:870
+#: src/window.rs:898
 msgid "Settings"
 msgstr ""
 
-#: src/window.rs:871
+#: src/window.rs:899
 msgid "Failed to get settings"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-16 14:15+0200\n"
+"POT-Creation-Date: 2026-08-18 11:18+0200\n"
 "PO-Revision-Date: 2025-11-12 20:10+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -71,210 +71,226 @@ msgid "Alexandre Del Bigio"
 msgstr "Alexandre Del Bigio"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:50
-msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgid ""
+"Fix non-utf-8 file names, markup in attachment rows and a print leak "
+"(shakaran)"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:51
-msgid "Spanish translation (thanks to shakaran)"
+msgid "Improve temporary file cleanup (shakaran)"
 msgstr ""
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:58
+msgid ""
+"Fix print shortcut, attachment overwrite, runtime dir and zoom (thanks to "
+"shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:59
+msgid "Sanitize attachment names, restrict link schemes (thanks to shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:60
+msgid "Spanish translation (thanks to shakaran)"
+msgstr ""
+
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:67
 msgid "Display local time with UTC offset"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:65
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
 msgid "Better print support (escape HTML when printing text)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:66
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:75
 msgid "Outlook (msg) don't show text button if text field is empty"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:73
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:82
 msgid "Sync \"Show remote images\" status for html print"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:74
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:83
 msgid "Outlook (msg) now support HTML"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:81
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:90
 msgid "Feature : Print (in menu)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:88
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:97
 msgid "Bug : revert changes (stdin) preventing opening from GNOME Files"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:95
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
 msgid ""
 "Test is data present on stdin if no file is provided (eg: cat sample.eml | "
 "mailviewer)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:102
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
 msgid "GitHub Actions rewrite (alescdb)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:103
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
 msgid "Use an encoding library to properly decode the contents (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:104
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
 msgid "Handle Windows-1252 encoding (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:105
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
 msgid "Log parsing errors as errors (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:106
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
 msgid "Use utils::span-and-wait to wait for web policy (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:107
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
 msgid "Expose spawn_and_wait to a generic utility crate (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:108
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
 msgid "Stop parsing early if action is cancelled (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:109
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
 msgid "Cancel previous loading operation using Cancellable (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:110
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
 msgid "Add test utility function to wait for futures to complete (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:111
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
 msgid "Add x-ole-storage as supported mime type (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:112
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
 msgid "Show a spinner while loading a message (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:113
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
 msgid "Run the messages parsing in a separate thread (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:114
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
 msgid "Bind visibility of action buttons to show text state (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:115
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
 msgid "Use gtk native future to open URIs / launch files (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:116
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
 msgid "Write the attachments on disk asynchronously (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:117
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:126
 msgid "Use better API to spawn futures from glib (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:118
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:127
 msgid "Use async loading of the files contents (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:119
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:128
 msgid "Check file asynchronously and based on content type (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:120
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:129
 msgid "it, fr translations: Update Plural forms definitions (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:121
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:130
 msgid "Updated Dutch translation (Vistaus)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:122
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:131
 msgid "Pre-set the file name when saving an attachment (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:123
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
 msgid "Use gtk4::FileDialog to open and save files (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
 msgid "Use ngettext to translate plural forms (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:134
 msgid "Bump msg_parser to 0.1.2 (3v1n0)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:132
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:141
 msgid "GNOME 49 (libadwaita 1.8)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:133
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:142
 msgid "Other dependencies updated"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:140
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:149
 msgid "Italian translation by albanobattistella"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:147
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:156
 msgid "Gnome 48 (libadwaita 1.7)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:154
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:163
 msgid "Dependency Updates"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:161
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
 msgid "Case insensitive file extensions"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:167
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:176
 msgid "Add I18N support"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:169
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:178
 msgid "French (fr_FR) by Me :-)"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:170
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:179
 msgid "Dutch (nl) by Heimen Stoffels"
 msgstr ""
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:177
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:186
 msgid "Add drag and drop support (file must have .eml or .msg extension)"
 msgstr ""
 "Nieuw: ondersteuning voor verslepen van .eml- en .msg-bestanden naar het "
 "venster"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:184
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:193
 msgid "Correct a crash when .msg has no attachments"
 msgstr "Opgelost: crash bij .msg-bestand zonder bijlagen"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:191
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:200
 msgid "Add support for Outlook .msg"
 msgstr "Nieuw: ondersteuning voor Outlook"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:198
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
 msgid "Fix flatpak version"
 msgstr "Gerepareerd: Flatpakversie"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:199
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:208
 msgid "Fix gmime-rs date memory problem"
 msgstr "Opgelost: datumgeheugenprobleem met gmime-rs"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:206
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:215
 msgid "Fix attachment adding up"
 msgstr "Opgelost: probleem omtrent bijlagen"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:207
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:216
 msgid "Fix gmime randomly crashing"
 msgstr "Opgelost: willekeurige crashes van gmime"
 
-#: data/io.github.alescdb.mailviewer.metainfo.xml.in:213
+#: data/io.github.alescdb.mailviewer.metainfo.xml.in:222
 msgid "First flatpak release"
 msgstr "Eerste Flatpakversie"
 
@@ -290,15 +306,20 @@ msgstr "Bestand openen"
 
 #: src/gtk/help-overlay.ui:20
 msgctxt "shortcut window"
+msgid "Print File"
+msgstr "Bestand afdrukken"
+
+#: src/gtk/help-overlay.ui:26
+msgctxt "shortcut window"
 msgid "Reset Zoom"
 msgstr "Oorspronkelijk zoomniveau"
 
-#: src/gtk/help-overlay.ui:26
+#: src/gtk/help-overlay.ui:32
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
 msgstr "Sneltoetsen tonen"
 
-#: src/gtk/help-overlay.ui:32
+#: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Afsluiten"
@@ -376,8 +397,8 @@ msgid "_Open..."
 msgstr "_Openen…"
 
 #: src/window.ui:260
-msgid "Print..."
-msgstr ""
+msgid "Pr_int..."
+msgstr "Af_drukken…"
 
 #: src/window.ui:264
 msgid "_Preferences"
@@ -395,56 +416,55 @@ msgstr "_Sneltoetsen"
 msgid "_About MailViewer"
 msgstr "Over MailWeerg_ave"
 
-#: src/window.rs:373
+#: src/window.rs:391
 msgid "Save as..."
 msgstr "Opslaan als…"
 
-#: src/window.rs:435
+#: src/window.rs:456
 msgid "Save attachment..."
 msgstr "Bijlage opslaan…"
 
-#: src/window.rs:449 src/window.rs:747
+#: src/window.rs:470 src/window.rs:773
 msgid "File Error"
 msgstr "Bestandsfout"
 
-#: src/window.rs:521
+#: src/window.rs:492 src/window.rs:774
+msgid "Failed to open file"
+msgstr "Het bestand kan niet worden geopend"
+
+#: src/window.rs:564
 #, fuzzy
 msgid "Failed to open uri"
 msgstr "Het bestand kan niet worden geopend"
 
-#: src/window.rs:578
+#: src/window.rs:621
 msgid "Mail Files"
 msgstr "Mailbestanden"
 
-#: src/window.rs:694
+#: src/window.rs:720
 msgid "Open Mail File"
 msgstr "Mailbestand openen"
 
-#: src/window.rs:748
-msgid "Failed to open file"
-msgstr "Het bestand kan niet worden geopend"
-
-#: src/window.rs:794
-#, rust-format
+#: src/window.rs:822
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} bijlage"
 msgstr[1] "{total} bijlagen"
 
 #. never shown
-#: src/window.rs:804
+#: src/window.rs:832
 msgid "No attachments"
 msgstr "Er zijn geen bijlagen"
 
-#: src/window.rs:818
+#: src/window.rs:846
 msgid "Close"
 msgstr "Sluiten"
 
-#: src/window.rs:870
+#: src/window.rs:898
 msgid "Settings"
 msgstr "Voorkeuren"
 
-#: src/window.rs:871
+#: src/window.rs:899
 msgid "Failed to get settings"
 msgstr "De voorkeuren zijn niet beschikbaar"
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -19,6 +19,7 @@
  */
 use adw::prelude::AdwDialogExt;
 use adw::subclass::prelude::*;
+use gettextrs::gettext;
 use gtk4::prelude::*;
 use gtk4::{gio, glib};
 
@@ -84,7 +85,7 @@ mod imp {
         Some(&glib::Variant::from(self.filename.borrow().clone())),
       ) {
         log::debug!("open_file_dialog({e})");
-        window.alert_error("File Error", &e.to_string(), false);
+        window.alert_error(&gettext("File Error"), &e.to_string(), false);
       }
     }
 

--- a/src/gtk/help-overlay.ui
+++ b/src/gtk/help-overlay.ui
@@ -17,6 +17,12 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Print File</property>
+                <property name="action-name">win.print</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Reset Zoom</property>
                 <property name="action-name">win.reset-zoom</property>
               </object>

--- a/src/window.ui
+++ b/src/window.ui
@@ -257,7 +257,7 @@
         <attribute name="action">win.open-file-dialog</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">Print...</attribute>
+        <attribute name="label" translatable="yes">Pr_int...</attribute>
         <attribute name="action">win.print</attribute>
       </item>
       <item>


### PR DESCRIPTION
Three small ones, plus the catalogs.

- `alert_error("File Error", ...)` in `application.rs` was the only place the string was hardcoded. It is already translated in the four catalogs, so wrapping it in `gettext()` is enough.
- `Print...` was the only menu entry without a mnemonic. P, R and A are taken by the entries around it, hence `Pr_int...`.
- The shortcuts window did not list printing, although it has had Ctrl+P since #36.

Both new strings are translated in es, fr, it and nl, with a free mnemonic in each: `_Imprimir…`, `_Imprimer...`, `S_tampa...`, `Af_drukken…`.

The Spanish catalog is complete again — the release notes added since were untranslated.

The bulk of the diff is the line references: the template is regenerated with xgettext and the catalogs merged with msgmerge. msgmerge leaves a couple of fuzzy suggestions in fr, it and nl (`Failed to open uri`, `Mail Files`), which gettext ignores at runtime; I left those alone since they are not my languages.

Checked with `msgfmt --check` on the four catalogs and by merging into the `.desktop` and `.metainfo.xml` templates.
