### PR TITLE
Follow the colour scheme when the css is forced

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -25,16 +25,38 @@ use base64::Engine;
 
 use crate::message::attachment::Attachment;
 
-pub const CSS: &str = r#"
+/// The style that replaces the one of the message when the css is forced.
+/// There are two, so that forcing it on a dark desktop does not turn the
+/// message into a white slab.
+const CSS_LIGHT: &str = r#"
 <style>
   * {
-    color: black; 
+    color: black;
     background-color: white;
     font-family: Poppins, Roboto, sans-serif;
     font-size: 20px;
   }
 </style>
 "#;
+
+const CSS_DARK: &str = r#"
+<style>
+  * {
+    color: #ffffff;
+    background-color: #242424;
+    font-family: Poppins, Roboto, sans-serif;
+    font-size: 20px;
+  }
+</style>
+"#;
+
+pub fn forced_css(dark: bool) -> &'static str {
+  if dark {
+    CSS_DARK
+  } else {
+    CSS_LIGHT
+  }
+}
 
 /// Removing tags is not enough to keep a message offline : css can reach the
 /// network on its own through @import, @font-face and url(). A policy is
@@ -51,6 +73,7 @@ pub struct Html {
   body: String,
   strip_css: bool,
   allow_remote: bool,
+  dark: bool,
   inline_images: HashMap<String, String>,
 }
 
@@ -60,6 +83,7 @@ impl Html {
       body: body.to_string(),
       strip_css,
       allow_remote: false,
+      dark: false,
       inline_images: HashMap::new(),
     }
   }
@@ -68,6 +92,14 @@ impl Html {
   /// the "Show remote images" button.
   pub fn allow_remote(mut self, allow_remote: bool) -> Self {
     self.allow_remote = allow_remote;
+    self
+  }
+
+  /// Whether the forced css is the dark one, i.e. the colour scheme of the
+  /// desktop. Only used when the css is forced : the style a message brings is
+  /// left alone, recolouring it would break as much as it fixes.
+  pub fn dark(mut self, dark: bool) -> Self {
+    self.dark = dark;
     self
   }
 
@@ -116,7 +148,11 @@ impl Html {
         "{}</head><body>{}</body></html>"
       ),
       policy,
-      if self.strip_css { CSS } else { "" },
+      if self.strip_css {
+        forced_css(self.dark)
+      } else {
+        ""
+      },
       self.clean()
     )
   }
@@ -271,9 +307,32 @@ mod tests {
     assert!(!body.contains("<applet"));
     assert!(!body.contains("<form"));
 
-    assert!(body.contains(&crate::html::CSS.to_lowercase()));
+    assert!(body.contains(&crate::html::forced_css(false).to_lowercase()));
 
     Ok(())
+  }
+
+  #[test]
+  fn forcing_the_css_follows_the_colour_scheme() {
+    let light = Html::new("<p>hi</p>", true).safe();
+    let dark = Html::new("<p>hi</p>", true).dark(true).safe();
+
+    assert!(light.contains("background-color: white"));
+    assert!(!light.contains("#242424"));
+    assert!(dark.contains("background-color: #242424"));
+    assert!(!dark.contains("background-color: white"));
+  }
+
+  #[test]
+  fn the_style_of_the_message_is_left_alone_in_the_dark() {
+    // Only the forced css carries our colours; recolouring a message that
+    // brings its own style would break as much as it fixes.
+    let body = Html::new("<p style=\"color: #333\">hi</p>", false)
+      .dark(true)
+      .safe();
+
+    assert!(!body.contains("#242424"));
+    assert!(body.contains("color: #333"));
   }
 
   #[test]

--- a/src/window.rs
+++ b/src/window.rs
@@ -797,9 +797,12 @@ impl MailViewerWindow {
     }
 
     if let Some(html) = imp.service.body_html() {
+      // The button keeps its state across messages, so the new one has to be
+      // rendered the way it says.
+      let force_css = imp.force_css.is_active();
       imp
         .webview
-        .load_html(&self.sanitized_html(&html, false), None);
+        .load_html(&self.sanitized_html(&html, force_css), None);
       has_html = true;
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -322,6 +322,19 @@ impl MailViewerWindow {
       }
     ));
 
+    // The forced css carries the colours, so it has to be rendered again when
+    // the desktop switches between light and dark.
+    adw::StyleManager::default().connect_dark_notify(clone!(
+      #[weak(rename_to = window)]
+      self,
+      move |_| {
+        if window.imp().force_css.is_active() {
+          log::debug!("colour scheme changed, rendering again");
+          window.load_html(true);
+        }
+      }
+    ));
+
     imp.webview.connect_decide_policy(clone!(
       #[strong]
       win,
@@ -522,6 +535,7 @@ impl MailViewerWindow {
   fn sanitized_html(&self, html: &str, force_css: bool) -> String {
     Html::new(html, force_css)
       .allow_remote(self.imp().show_images.is_active())
+      .dark(adw::StyleManager::default().is_dark())
       .inline_images(&self.imp().service.attachments())
       .safe()
   }


### PR DESCRIPTION
`TODO.md` has "CSS dark mode ?", so here is one reading of it.

Forcing the css replaced the style of the message with black on white, which on a dark desktop makes the message a white slab. There are two palettes now, picked from `AdwStyleManager`, and the message is rendered again when the desktop switches between light and dark.

Only the forced css carries the colours. A message that brings its own style is left alone: recolouring arbitrary mail breaks as much as it fixes, since a message that sets a text colour but no background ends up dark on dark. That is the part I would rather leave to you if you want to go further.

The first commit is a fix that the second one needs: `display_message()` always rendered with the css not forced, so turning the button on and then opening another message dropped the style again, with the button still lit.

Two tests: the palette follows the colour scheme, and a message with its own style is untouched in dark. I checked the wiring at runtime with `ADW_DEBUG_COLOR_SCHEME`, `is_dark()` comes out true and false as expected.
