### PR TITLE
Find in the message with Ctrl+F

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -93,9 +93,8 @@ msgstr ""
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:55
 msgid "Fix non-UTF-8 filenames and markup in attachment rows (shakaran)"
 msgstr ""
-"Se corrigen los nombres de archivo que no son UTF-8 y el markup en las filas "
-"de adjuntos (shakaran)Se corrigen los nombres de archivo que no son UTF-8, el "
-"markup en las filas de adjuntos y una fuga al imprimir (gracias a shakaran)"
+"Se corrigen los nombres de archivo que no son UTF-8 y el marcado en las filas "
+"de adjuntos (shakaran)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:56
 msgid "Improve temporary file cleanup (shakaran)"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 11:46+0200\n"
+"POT-Creation-Date: 2026-08-18 20:49+0200\n"
 "PO-Revision-Date: 2026-08-12 22:15+0200\n"
 "Last-Translator: Ángel Guzmán Maeso <angel@guzmanmaeso.com>\n"
 "Language-Team: Spanish <LL@li.org>\n"
@@ -70,30 +70,32 @@ msgstr "Alexandre Del Bigio"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:50
 msgid "Fix printing to file and PDF"
-msgstr ""
+msgstr "Se corrige la impresión a archivo y a PDF"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:51
 msgid "Disable zoom buttons at the minimum and maximum zoom levels"
-msgstr ""
+msgstr "Se desactivan los botones de zoom al llegar al mínimo y al máximo"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:52
 msgid "Improve HTML email sanitization and security (shakaran)"
-msgstr ""
+msgstr "Se mejoran el saneado y la seguridad del HTML de los correos (shakaran)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:53
 msgid "Block unwanted remote content in emails (shakaran)"
-msgstr ""
+msgstr "Se bloquea el contenido remoto no deseado de los correos (shakaran)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:54
 msgid "Improve HTML escaping for filenames and message metadata"
 msgstr ""
+"Se mejora el escapado de HTML en los nombres de archivo y en los metadatos "
+"del mensaje"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:55
-#, fuzzy
 msgid "Fix non-UTF-8 filenames and markup in attachment rows (shakaran)"
 msgstr ""
-"Se corrigen los nombres de archivo que no son UTF-8, el markup en las filas "
-"de adjuntos y una fuga al imprimir (gracias a shakaran)"
+"Se corrigen los nombres de archivo que no son UTF-8 y el markup en las filas "
+"de adjuntos (shakaran)Se corrigen los nombres de archivo que no son UTF-8, el "
+"markup en las filas de adjuntos y una fuga al imprimir (gracias a shakaran)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:56
 msgid "Improve temporary file cleanup (shakaran)"
@@ -129,8 +131,7 @@ msgstr ""
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:80
 msgid "Outlook (msg) don't show text button if text field is empty"
 msgstr ""
-"Outlook (msg): no se muestra el botón de texto si el campo de texto está "
-"vacío"
+"Outlook (msg): no se muestra el botón de texto si el campo de texto está vacío"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:87
 msgid "Sync \"Show remote images\" status for html print"
@@ -196,8 +197,7 @@ msgstr "Se cancela la carga anterior mediante Cancellable (3v1n0)"
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:124
 msgid "Add test utility function to wait for futures to complete (3v1n0)"
 msgstr ""
-"Se añade una función de prueba para esperar a que terminen los futuros "
-"(3v1n0)"
+"Se añade una función de prueba para esperar a que terminen los futuros (3v1n0)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:125
 msgid "Add x-ole-storage as supported mime type (3v1n0)"
@@ -354,15 +354,20 @@ msgstr "Imprimir archivo"
 
 #: src/gtk/help-overlay.ui:26
 msgctxt "shortcut window"
+msgid "Find in Message"
+msgstr "Buscar en el mensaje"
+
+#: src/gtk/help-overlay.ui:32
+msgctxt "shortcut window"
 msgid "Reset Zoom"
 msgstr "Restablecer el zoom"
 
-#: src/gtk/help-overlay.ui:32
+#: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
 msgstr "Mostrar los atajos"
 
-#: src/gtk/help-overlay.ui:38
+#: src/gtk/help-overlay.ui:44
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Salir"
@@ -427,86 +432,85 @@ msgstr "Asunto:"
 msgid "Subject"
 msgstr "Asunto"
 
-#: src/window.ui:178
+#: src/window.ui:193
 msgid "HTML"
 msgstr "HTML"
 
-#: src/window.ui:190
+#: src/window.ui:205
 msgid "TEXT"
 msgstr "TEXTO"
 
-#: src/window.ui:256
+#: src/window.ui:271
 msgid "_Open..."
 msgstr "_Abrir…"
 
-#: src/window.ui:260
+#: src/window.ui:275
 msgid "Pr_int..."
 msgstr "_Imprimir…"
 
-#: src/window.ui:264
+#: src/window.ui:279
 msgid "_Preferences"
 msgstr "_Preferencias"
 
-#: src/window.ui:268
+#: src/window.ui:283
 msgid "_Reset Zoom"
 msgstr "_Restablecer el zoom"
 
-#: src/window.ui:272
+#: src/window.ui:287
 msgid "_Keyboard Shortcuts"
 msgstr "Atajos de _teclado"
 
-#: src/window.ui:276
+#: src/window.ui:291
 msgid "_About MailViewer"
 msgstr "Acerca _de MailViewer"
 
-#: src/window.rs:391
+#: src/window.rs:457
 msgid "Save as..."
 msgstr "Guardar como…"
 
-#: src/window.rs:456
+#: src/window.rs:522
 msgid "Save attachment..."
 msgstr "Guardar el adjunto…"
 
-#: src/window.rs:470 src/window.rs:773
+#: src/window.rs:536 src/window.rs:840
 msgid "File Error"
 msgstr "Error de archivo"
 
-#: src/window.rs:564
-msgid "Failed to open uri"
-msgstr "No se pudo abrir el URI"
-
-#: src/window.rs:621
-msgid "Mail Files"
-msgstr "Archivos de correo"
-
-#: src/window.rs:720
-msgid "Open Mail File"
-msgstr "Abrir un archivo de correo"
-
-#: src/window.rs:774
+#: src/window.rs:558 src/window.rs:841
 msgid "Failed to open file"
 msgstr "No se pudo abrir el archivo"
 
-#: src/window.rs:822
-#, rust-format
+#: src/window.rs:630
+msgid "Failed to open uri"
+msgstr "No se pudo abrir el URI"
+
+#: src/window.rs:687
+msgid "Mail Files"
+msgstr "Archivos de correo"
+
+#: src/window.rs:786
+msgid "Open Mail File"
+msgstr "Abrir un archivo de correo"
+
+#: src/window.rs:889
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} adjunto"
 msgstr[1] "{total} adjuntos"
 
 #. never shown
-#: src/window.rs:832
+#: src/window.rs:899
 msgid "No attachments"
 msgstr "Sin adjuntos"
 
-#: src/window.rs:846
+#: src/window.rs:913
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/window.rs:898
+#: src/window.rs:965
 msgid "Settings"
 msgstr "Configuración"
 
-#: src/window.rs:899
+#: src/window.rs:966
 msgid "Failed to get settings"
 msgstr "No se pudo obtener la configuración"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 11:46+0200\n"
+"POT-Creation-Date: 2026-08-18 20:49+0200\n"
 "PO-Revision-Date: 2024-11-14 17:23+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -332,15 +332,20 @@ msgstr "Imprimer un fichier"
 
 #: src/gtk/help-overlay.ui:26
 msgctxt "shortcut window"
+msgid "Find in Message"
+msgstr "Rechercher dans le message"
+
+#: src/gtk/help-overlay.ui:32
+msgctxt "shortcut window"
 msgid "Reset Zoom"
 msgstr "Réinitialiser le zoom"
 
-#: src/gtk/help-overlay.ui:32
+#: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
 msgstr "Afficher les raccourcis"
 
-#: src/gtk/help-overlay.ui:38
+#: src/gtk/help-overlay.ui:44
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Quitter"
@@ -405,87 +410,86 @@ msgstr "Sujet:"
 msgid "Subject"
 msgstr "Sujet"
 
-#: src/window.ui:178
+#: src/window.ui:193
 msgid "HTML"
 msgstr "HTML"
 
-#: src/window.ui:190
+#: src/window.ui:205
 msgid "TEXT"
 msgstr "TEXTE"
 
-#: src/window.ui:256
+#: src/window.ui:271
 msgid "_Open..."
 msgstr "_Ouvrir..."
 
-#: src/window.ui:260
+#: src/window.ui:275
 msgid "Pr_int..."
 msgstr "_Imprimer..."
 
-#: src/window.ui:264
+#: src/window.ui:279
 msgid "_Preferences"
 msgstr "_Préférences"
 
-#: src/window.ui:268
+#: src/window.ui:283
 msgid "_Reset Zoom"
 msgstr "_Réinitialiser le zoom"
 
-#: src/window.ui:272
+#: src/window.ui:287
 msgid "_Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
-#: src/window.ui:276
+#: src/window.ui:291
 msgid "_About MailViewer"
 msgstr "_A propos de MailViewer"
 
-#: src/window.rs:391
+#: src/window.rs:457
 msgid "Save as..."
 msgstr "Enregister sous..."
 
-#: src/window.rs:456
+#: src/window.rs:522
 msgid "Save attachment..."
 msgstr "Enregister le fichier attaché..."
 
-#: src/window.rs:470 src/window.rs:773
+#: src/window.rs:536 src/window.rs:840
 msgid "File Error"
 msgstr "Erreur de fichier"
 
-#: src/window.rs:564
-msgid "Failed to open uri"
-msgstr "Impossible d'ouvrir le fichier"
-
-#: src/window.rs:621
-msgid "Mail Files"
-msgstr "Ouvrir un fichier"
-
-#: src/window.rs:720
-msgid "Open Mail File"
-msgstr "Ouvrir un message"
-
-#: src/window.rs:774
+#: src/window.rs:558 src/window.rs:841
 msgid "Failed to open file"
 msgstr "Impossible d'ouvrir le fichier"
 
-#: src/window.rs:822
-#, rust-format
+#: src/window.rs:630
+msgid "Failed to open uri"
+msgstr "Impossible d'ouvrir le fichier"
+
+#: src/window.rs:687
+msgid "Mail Files"
+msgstr "Ouvrir un fichier"
+
+#: src/window.rs:786
+msgid "Open Mail File"
+msgstr "Ouvrir un message"
+
+#: src/window.rs:889
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} fichier attaché"
 msgstr[1] "{total} fichiers attachés"
 
 #. never shown
-#: src/window.rs:832
+#: src/window.rs:899
 msgid "No attachments"
 msgstr "Aucun fichier attaché"
 
-#: src/window.rs:846
+#: src/window.rs:913
 msgid "Close"
 msgstr "Fermer"
 
-#: src/window.rs:898
+#: src/window.rs:965
 msgid "Settings"
 msgstr "Préférences"
 
-#: src/window.rs:899
+#: src/window.rs:966
 msgid "Failed to get settings"
 msgstr "Impossible de trouver les préférences"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 11:46+0200\n"
+"POT-Creation-Date: 2026-08-18 20:49+0200\n"
 "PO-Revision-Date: 2025-05-07 22:22+0100\n"
 "Last-Translator: Albano Battistella <albanobattistella@gmail.com>\n"
 "Language-Team: Italian <LL@li.org>\n"
@@ -327,15 +327,20 @@ msgstr "Stampa file"
 
 #: src/gtk/help-overlay.ui:26
 msgctxt "shortcut window"
+msgid "Find in Message"
+msgstr "Cerca nel messaggio"
+
+#: src/gtk/help-overlay.ui:32
+msgctxt "shortcut window"
 msgid "Reset Zoom"
 msgstr "Reimposta zoom"
 
-#: src/gtk/help-overlay.ui:32
+#: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
 msgstr "Mostra scorciatoie"
 
-#: src/gtk/help-overlay.ui:38
+#: src/gtk/help-overlay.ui:44
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Esci"
@@ -400,87 +405,86 @@ msgstr "Soggetto:"
 msgid "Subject"
 msgstr "Soggetto:"
 
-#: src/window.ui:178
+#: src/window.ui:193
 msgid "HTML"
 msgstr "HTML"
 
-#: src/window.ui:190
+#: src/window.ui:205
 msgid "TEXT"
 msgstr "TESTO"
 
-#: src/window.ui:256
+#: src/window.ui:271
 msgid "_Open..."
 msgstr "_Apri..."
 
-#: src/window.ui:260
+#: src/window.ui:275
 msgid "Pr_int..."
 msgstr "S_tampa..."
 
-#: src/window.ui:264
+#: src/window.ui:279
 msgid "_Preferences"
 msgstr "_Preferenze"
 
-#: src/window.ui:268
+#: src/window.ui:283
 msgid "_Reset Zoom"
 msgstr "_Reimposta zoom"
 
-#: src/window.ui:272
+#: src/window.ui:287
 msgid "_Keyboard Shortcuts"
 msgstr "_Scorciatoie da tastiera"
 
-#: src/window.ui:276
+#: src/window.ui:291
 msgid "_About MailViewer"
 msgstr "_Informazioni su MailViewer"
 
-#: src/window.rs:391
+#: src/window.rs:457
 msgid "Save as..."
 msgstr "Salva con nome..."
 
-#: src/window.rs:456
+#: src/window.rs:522
 msgid "Save attachment..."
 msgstr "Salva allegato..."
 
-#: src/window.rs:470 src/window.rs:773
+#: src/window.rs:536 src/window.rs:840
 msgid "File Error"
 msgstr "Errore file"
 
-#: src/window.rs:564
-msgid "Failed to open uri"
-msgstr "Impossibile aprire il file"
-
-#: src/window.rs:621
-msgid "Mail Files"
-msgstr "Apri file di posta"
-
-#: src/window.rs:720
-msgid "Open Mail File"
-msgstr "Apri file di posta"
-
-#: src/window.rs:774
+#: src/window.rs:558 src/window.rs:841
 msgid "Failed to open file"
 msgstr "Impossibile aprire il file"
 
-#: src/window.rs:822
-#, rust-format
+#: src/window.rs:630
+msgid "Failed to open uri"
+msgstr "Impossibile aprire il file"
+
+#: src/window.rs:687
+msgid "Mail Files"
+msgstr "Apri file di posta"
+
+#: src/window.rs:786
+msgid "Open Mail File"
+msgstr "Apri file di posta"
+
+#: src/window.rs:889
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} allegato"
 msgstr[1] "{total} allegati"
 
 #. never shown
-#: src/window.rs:832
+#: src/window.rs:899
 msgid "No attachments"
 msgstr "Nessun allegato"
 
-#: src/window.rs:846
+#: src/window.rs:913
 msgid "Close"
 msgstr "Chiudi"
 
-#: src/window.rs:898
+#: src/window.rs:965
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/window.rs:899
+#: src/window.rs:966
 msgid "Failed to get settings"
 msgstr "Impossibile ottenere le impostazioni"
 

--- a/po/mailviewer.pot
+++ b/po/mailviewer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 11:46+0200\n"
+"POT-Creation-Date: 2026-08-18 20:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -321,15 +321,20 @@ msgstr ""
 
 #: src/gtk/help-overlay.ui:26
 msgctxt "shortcut window"
-msgid "Reset Zoom"
+msgid "Find in Message"
 msgstr ""
 
 #: src/gtk/help-overlay.ui:32
 msgctxt "shortcut window"
-msgid "Show Shortcuts"
+msgid "Reset Zoom"
 msgstr ""
 
 #: src/gtk/help-overlay.ui:38
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr ""
+
+#: src/gtk/help-overlay.ui:44
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr ""
@@ -394,86 +399,85 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: src/window.ui:178
+#: src/window.ui:193
 msgid "HTML"
 msgstr ""
 
-#: src/window.ui:190
+#: src/window.ui:205
 msgid "TEXT"
 msgstr ""
 
-#: src/window.ui:256
+#: src/window.ui:271
 msgid "_Open..."
 msgstr ""
 
-#: src/window.ui:260
+#: src/window.ui:275
 msgid "Pr_int..."
 msgstr ""
 
-#: src/window.ui:264
+#: src/window.ui:279
 msgid "_Preferences"
 msgstr ""
 
-#: src/window.ui:268
+#: src/window.ui:283
 msgid "_Reset Zoom"
 msgstr ""
 
-#: src/window.ui:272
+#: src/window.ui:287
 msgid "_Keyboard Shortcuts"
 msgstr ""
 
-#: src/window.ui:276
+#: src/window.ui:291
 msgid "_About MailViewer"
 msgstr ""
 
-#: src/window.rs:391
+#: src/window.rs:457
 msgid "Save as..."
 msgstr ""
 
-#: src/window.rs:456
+#: src/window.rs:522
 msgid "Save attachment..."
 msgstr ""
 
-#: src/window.rs:470 src/window.rs:773
+#: src/window.rs:536 src/window.rs:840
 msgid "File Error"
 msgstr ""
 
-#: src/window.rs:564
-msgid "Failed to open uri"
-msgstr ""
-
-#: src/window.rs:621
-msgid "Mail Files"
-msgstr ""
-
-#: src/window.rs:720
-msgid "Open Mail File"
-msgstr ""
-
-#: src/window.rs:774
+#: src/window.rs:558 src/window.rs:841
 msgid "Failed to open file"
 msgstr ""
 
-#: src/window.rs:822
-#, rust-format
+#: src/window.rs:630
+msgid "Failed to open uri"
+msgstr ""
+
+#: src/window.rs:687
+msgid "Mail Files"
+msgstr ""
+
+#: src/window.rs:786
+msgid "Open Mail File"
+msgstr ""
+
+#: src/window.rs:889
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] ""
 msgstr[1] ""
 
 #. never shown
-#: src/window.rs:832
+#: src/window.rs:899
 msgid "No attachments"
 msgstr ""
 
-#: src/window.rs:846
+#: src/window.rs:913
 msgid "Close"
 msgstr ""
 
-#: src/window.rs:898
+#: src/window.rs:965
 msgid "Settings"
 msgstr ""
 
-#: src/window.rs:899
+#: src/window.rs:966
 msgid "Failed to get settings"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-18 11:46+0200\n"
+"POT-Creation-Date: 2026-08-18 20:49+0200\n"
 "PO-Revision-Date: 2025-11-12 20:10+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -329,15 +329,20 @@ msgstr "Bestand afdrukken"
 
 #: src/gtk/help-overlay.ui:26
 msgctxt "shortcut window"
+msgid "Find in Message"
+msgstr "Zoeken in bericht"
+
+#: src/gtk/help-overlay.ui:32
+msgctxt "shortcut window"
 msgid "Reset Zoom"
 msgstr "Oorspronkelijk zoomniveau"
 
-#: src/gtk/help-overlay.ui:32
+#: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
 msgstr "Sneltoetsen tonen"
 
-#: src/gtk/help-overlay.ui:38
+#: src/gtk/help-overlay.ui:44
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr "Afsluiten"
@@ -402,87 +407,86 @@ msgstr "Onderwerp:"
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: src/window.ui:178
+#: src/window.ui:193
 msgid "HTML"
 msgstr "Html"
 
-#: src/window.ui:190
+#: src/window.ui:205
 msgid "TEXT"
 msgstr "Tekst"
 
-#: src/window.ui:256
+#: src/window.ui:271
 msgid "_Open..."
 msgstr "_Openen…"
 
-#: src/window.ui:260
+#: src/window.ui:275
 msgid "Pr_int..."
 msgstr "Af_drukken…"
 
-#: src/window.ui:264
+#: src/window.ui:279
 msgid "_Preferences"
 msgstr "_Voorkeuren"
 
-#: src/window.ui:268
+#: src/window.ui:283
 msgid "_Reset Zoom"
 msgstr "Oo_rspronkelijk zoomniveau"
 
-#: src/window.ui:272
+#: src/window.ui:287
 msgid "_Keyboard Shortcuts"
 msgstr "_Sneltoetsen"
 
-#: src/window.ui:276
+#: src/window.ui:291
 msgid "_About MailViewer"
 msgstr "Over MailWeerg_ave"
 
-#: src/window.rs:391
+#: src/window.rs:457
 msgid "Save as..."
 msgstr "Opslaan als…"
 
-#: src/window.rs:456
+#: src/window.rs:522
 msgid "Save attachment..."
 msgstr "Bijlage opslaan…"
 
-#: src/window.rs:470 src/window.rs:773
+#: src/window.rs:536 src/window.rs:840
 msgid "File Error"
 msgstr "Bestandsfout"
 
-#: src/window.rs:564
-msgid "Failed to open uri"
-msgstr "Kan de URI niet openen"
-
-#: src/window.rs:621
-msgid "Mail Files"
-msgstr "Mailbestanden"
-
-#: src/window.rs:720
-msgid "Open Mail File"
-msgstr "Mailbestand openen"
-
-#: src/window.rs:774
+#: src/window.rs:558 src/window.rs:841
 msgid "Failed to open file"
 msgstr "Kan de URI niet openen"
 
-#: src/window.rs:822
-#, rust-format
+#: src/window.rs:630
+msgid "Failed to open uri"
+msgstr "Kan de URI niet openen"
+
+#: src/window.rs:687
+msgid "Mail Files"
+msgstr "Mailbestanden"
+
+#: src/window.rs:786
+msgid "Open Mail File"
+msgstr "Mailbestand openen"
+
+#: src/window.rs:889
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} bijlage"
 msgstr[1] "{total} bijlagen"
 
 #. never shown
-#: src/window.rs:832
+#: src/window.rs:899
 msgid "No attachments"
 msgstr "Er zijn geen bijlagen"
 
-#: src/window.rs:846
+#: src/window.rs:913
 msgid "Close"
 msgstr "Sluiten"
 
-#: src/window.rs:898
+#: src/window.rs:965
 msgid "Settings"
 msgstr "Voorkeuren"
 
-#: src/window.rs:899
+#: src/window.rs:966
 msgid "Failed to get settings"
 msgstr "De voorkeuren zijn niet beschikbaar"
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -54,6 +54,7 @@ mod imp {
       obj.set_accels_for_action("win.open-file-dialog", &["<primary>o"]);
       obj.set_accels_for_action("win.print", &["<primary>p"]);
       obj.set_accels_for_action("win.reset-zoom", &["<primary>r"]);
+      obj.set_accels_for_action("win.search", &["<primary>f"]);
     }
   }
 

--- a/src/gtk/help-overlay.ui
+++ b/src/gtk/help-overlay.ui
@@ -23,6 +23,12 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Find in Message</property>
+                <property name="action-name">win.search</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Reset Zoom</property>
                 <property name="action-name">win.reset-zoom</property>
               </object>

--- a/src/window.rs
+++ b/src/window.rs
@@ -26,7 +26,7 @@ use gettextrs::{gettext, ngettext};
 use gtk4::{gio, glib, template_callbacks};
 use webkit6::prelude::{PolicyDecisionExt, WebViewExt};
 use webkit6::{
-  NavigationPolicyDecision, PolicyDecision, PolicyDecisionType, PrintOperation, PrintOperationResponse, WebView
+  FindOptions, NavigationPolicyDecision, PolicyDecision, PolicyDecisionType, PrintOperation, PrintOperationResponse, WebView
 };
 
 use crate::html::Html;
@@ -88,6 +88,10 @@ mod imp {
     pub content_box: TemplateChild<gtk4::Box>,
     #[template_child]
     pub attachments_clamp: TemplateChild<adw::Clamp>,
+    #[template_child]
+    pub search_bar: TemplateChild<gtk4::SearchBar>,
+    #[template_child]
+    pub search_entry: TemplateChild<gtk4::SearchEntry>,
     //
     pub scrolled_window: ScrolledWindow,
     pub network_session: webkit6::NetworkSession,
@@ -125,6 +129,8 @@ mod imp {
         stack: TemplateChild::default(),
         pull_label: TemplateChild::default(),
         attachments_clamp: TemplateChild::default(),
+        search_bar: TemplateChild::default(),
+        search_entry: TemplateChild::default(),
         content_box: TemplateChild::default(),
         sheet: TemplateChild::default(),
         settings: OnceCell::new(),
@@ -182,6 +188,9 @@ mod imp {
           }
         },
       );
+      klass.install_action("win.search", None, move |win, _, _| {
+        win.start_search();
+      });
       klass.install_action("win.preferences", None, move |win, _, _| {
         win.show_preferences();
       });
@@ -251,6 +260,62 @@ impl MailViewerWindow {
     self.imp().websettings.set_auto_load_images(show);
     // The policy travels with the html, so the message has to be rendered again.
     self.load_html(self.imp().force_css.is_active());
+  }
+
+  /// Ctrl+F. The bar rides on the html view, the plain text one is a
+  /// GtkTextView and does not go through the find controller.
+  fn start_search(&self) {
+    if self.imp().show_text.is_active() {
+      return;
+    }
+    self.imp().search_bar.set_search_mode(true);
+    self.imp().search_entry.grab_focus();
+  }
+
+  fn find_controller(&self) -> Option<webkit6::FindController> {
+    self.imp().webview.find_controller()
+  }
+
+  #[template_callback]
+  pub fn on_search_changed(&self) {
+    let text = self.imp().search_entry.text();
+    let Some(controller) = self.find_controller() else {
+      return;
+    };
+
+    if text.is_empty() {
+      controller.search_finish();
+      return;
+    }
+    log::debug!("on_search_changed({})", text);
+    controller.search(
+      &text,
+      (FindOptions::CASE_INSENSITIVE | FindOptions::WRAP_AROUND).bits(),
+      u32::MAX,
+    );
+  }
+
+  #[template_callback]
+  pub fn on_search_next(&self) {
+    if let Some(controller) = self.find_controller() {
+      controller.search_next();
+    }
+  }
+
+  #[template_callback]
+  pub fn on_search_previous(&self) {
+    if let Some(controller) = self.find_controller() {
+      controller.search_previous();
+    }
+  }
+
+  #[template_callback]
+  pub fn on_search_stopped(&self) {
+    log::debug!("on_search_stopped()");
+    if let Some(controller) = self.find_controller() {
+      controller.search_finish();
+    }
+    self.imp().search_bar.set_search_mode(false);
   }
 
   #[template_callback]
@@ -740,6 +805,7 @@ impl MailViewerWindow {
     log::debug!("open_file({:?})", file.peek_path().unwrap_or_default());
 
     self.on_show_text(true);
+    self.on_search_stopped();
     self.imp().content_box.get().set_sensitive(false);
     self.imp().sheet.get().set_open(false);
 

--- a/src/window.ui
+++ b/src/window.ui
@@ -171,6 +171,21 @@
                   </object>
                 </child>
                 <child>
+                  <object class="GtkSearchBar" id="search_bar">
+                    <property name="visible" bind-source="show_text"
+                        bind-property="active" bind-flags="invert-boolean | sync-create" />
+                    <property name="child">
+                      <object class="GtkSearchEntry" id="search_entry">
+                        <property name="hexpand">true</property>
+                        <signal name="search-changed" handler="on_search_changed" swapped="true" />
+                        <signal name="next-match" handler="on_search_next" swapped="true" />
+                        <signal name="previous-match" handler="on_search_previous" swapped="true" />
+                        <signal name="stop-search" handler="on_search_stopped" swapped="true" />
+                      </object>
+                    </property>
+                  </object>
+                </child>
+                <child>
                   <object class="AdwViewStack" id="stack">
                     <child>
                       <object class="AdwViewStackPage">


### PR DESCRIPTION
A search bar over the html view, wired to the find controller of the web view: case insensitive, wrapping around, next and previous from the arrows of the entry, escape to close. Opening another message closes it.

It rides on the html view only. The plain text one is a `GtkTextView`, which does not go through the find controller, so the bar hides with the same binding to `show_text` that the buttons in the header already use. Searching the text view needs a different mechanism (`forward_search`, highlight tags, tracking the current match), which felt like its own change rather than padding this one.

Ctrl+F, listed in the shortcuts window, with the string translated in es, fr, it and nl. The Spanish catalog is complete again, five release notes were untranslated.

I checked the controller at runtime by driving a search from code: one match for a word in `sample.eml`, none for a string that is not there.
