### PR TITLE
Keep the zoom buttons in step with the saved zoom

### DIFF
--- a/data/io.github.alescdb.mailviewer.gschema.xml
+++ b/data/io.github.alescdb.mailviewer.gschema.xml
@@ -15,6 +15,7 @@
     </key>
     <key name="zoom" type="d">
       <default>1.0</default>
+      <range min="0.3" max="5.0"/>
     </key>
     <key name="show-file-name" type="b">
       <default>true</default>

--- a/src/window.rs
+++ b/src/window.rs
@@ -415,9 +415,9 @@ impl MailViewerWindow {
     let imp = self.imp();
 
     imp.settings.set(settings.clone()).unwrap();
-    imp
-      .webview
-      .set_zoom_level(settings.get::<f64>("zoom").clamp(ZOOM_MIN, ZOOM_MAX));
+    // set_zoom_level() is what enables and disables the zoom buttons, going
+    // straight to the view leaves them out of step with the saved zoom.
+    self.set_zoom_level(settings.get::<f64>("zoom"));
 
     settings
       .bind("width", self, "default-width")


### PR DESCRIPTION
`initialize_settings()` sets the zoom on the view directly, skipping `set_zoom_level()`, which is where the code that enables and disables the buttons lives. Opening the application with the zoom saved at 5.0 leaves the `+` button sensitive and doing nothing, same with 0.3 and `-`.

With `RUST_LOG=debug` and `zoom` at 5.0, before there is no `set_zoom()` at startup, after there is `set_zoom(5)`, so the buttons follow the saved value.

The schema now carries the same range the code clamps to. `gsettings set io.github.alescdb.mailviewer zoom 99.0` was accepted before and is rejected now.