### PR TITLE
Say when a message is signed or encrypted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "mailviewer-core"
 version = "0.1.0"
-source = "git+https://github.com/alescdb/mailviewer-core?branch=main#5cbd67d22bee258d80797d0be93af82f202e009f"
+source = "git+https://github.com/alescdb/mailviewer-core?branch=main#ac463f589c551cb1824199993e7f01f03e5cae91"
 dependencies = [
  "ammonia",
  "base64",

--- a/mailviewer-sources.json
+++ b/mailviewer-sources.json
@@ -2,8 +2,8 @@
     {
         "type": "git",
         "url": "https://github.com/alescdb/mailviewer-core",
-        "commit": "5cbd67d22bee258d80797d0be93af82f202e009f",
-        "dest": "flatpak-cargo/git/mailviewer-core-5cbd67d"
+        "commit": "ac463f589c551cb1824199993e7f01f03e5cae91",
+        "dest": "flatpak-cargo/git/mailviewer-core-ac463f5"
     },
     {
         "type": "archive",
@@ -1451,7 +1451,7 @@
     {
         "type": "shell",
         "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/mailviewer-core-5cbd67d/.\" \"cargo/vendor/mailviewer-core\""
+            "cp -r --reflink=auto \"flatpak-cargo/git/mailviewer-core-ac463f5/.\" \"cargo/vendor/mailviewer-core\""
         ]
     },
     {

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 19:32+0200\n"
+"POT-Creation-Date: 2026-08-24 19:42+0200\n"
 "PO-Revision-Date: 2026-08-12 22:15+0200\n"
 "Last-Translator: Ángel Guzmán Maeso <angel@guzmanmaeso.com>\n"
 "Language-Team: Spanish <LL@li.org>\n"
@@ -73,7 +73,8 @@ msgid "Search within HTML emails with Ctrl+F (by shakaran)"
 msgstr "Buscar dentro de los correos HTML con Ctrl+F (por shakaran)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:51
-msgid "Light and dark for HTML messages (if Force CSS is enabled) (by shakaran)"
+msgid ""
+"Light and dark for HTML messages (if Force CSS is enabled) (by shakaran)"
 msgstr ""
 "Claro y oscuro para los mensajes HTML (si se fuerza el CSS) (por shakaran)"
 
@@ -95,7 +96,8 @@ msgstr "Se desactivan los botones de zoom al llegar al mínimo y al máximo"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:62
 msgid "Improve HTML email sanitization and security (shakaran)"
-msgstr "Se mejoran el saneado y la seguridad del HTML de los correos (shakaran)"
+msgstr ""
+"Se mejoran el saneado y la seguridad del HTML de los correos (shakaran)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:63
 msgid "Block unwanted remote content in emails (shakaran)"
@@ -110,8 +112,8 @@ msgstr ""
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:65
 msgid "Fix non-UTF-8 filenames and markup in attachment rows (shakaran)"
 msgstr ""
-"Se corrigen los nombres de archivo que no son UTF-8 y el marcado en las filas "
-"de adjuntos (shakaran)"
+"Se corrigen los nombres de archivo que no son UTF-8 y el marcado en las "
+"filas de adjuntos (shakaran)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:66
 msgid "Improve temporary file cleanup (shakaran)"
@@ -147,7 +149,8 @@ msgstr ""
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:90
 msgid "Outlook (msg) don't show text button if text field is empty"
 msgstr ""
-"Outlook (msg): no se muestra el botón de texto si el campo de texto está vacío"
+"Outlook (msg): no se muestra el botón de texto si el campo de texto está "
+"vacío"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:97
 msgid "Sync \"Show remote images\" status for html print"
@@ -213,7 +216,8 @@ msgstr "Se cancela la carga anterior mediante Cancellable (3v1n0)"
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:134
 msgid "Add test utility function to wait for futures to complete (3v1n0)"
 msgstr ""
-"Se añade una función de prueba para esperar a que terminen los futuros (3v1n0)"
+"Se añade una función de prueba para esperar a que terminen los futuros "
+"(3v1n0)"
 
 #: data/io.github.alescdb.mailviewer.metainfo.xml.in:135
 msgid "Add x-ole-storage as supported mime type (3v1n0)"
@@ -452,86 +456,94 @@ msgstr "Asunto:"
 msgid "Subject"
 msgstr "Asunto"
 
-#: src/window.blp:171
+#: src/window.blp:175
 msgid "HTML"
 msgstr "HTML"
 
-#: src/window.blp:181
+#: src/window.blp:185
 msgid "TEXT"
 msgstr "TEXTO"
 
-#: src/window.blp:234
+#: src/window.blp:238
 msgid "_Open..."
 msgstr "_Abrir…"
 
-#: src/window.blp:239
+#: src/window.blp:243
 msgid "Pr_int..."
 msgstr "_Imprimir…"
 
-#: src/window.blp:244
+#: src/window.blp:248
 msgid "_Preferences"
 msgstr "_Preferencias"
 
-#: src/window.blp:249
+#: src/window.blp:253
 msgid "_Reset Zoom"
 msgstr "_Restablecer el zoom"
 
-#: src/window.blp:254
+#: src/window.blp:258
 msgid "_Keyboard Shortcuts"
 msgstr "Atajos de _teclado"
 
-#: src/window.blp:259
+#: src/window.blp:263
 msgid "_About MailViewer"
 msgstr "Acerca _de MailViewer"
 
-#: src/window.rs:476
+#: src/window.rs:480
 msgid "Save as..."
 msgstr "Guardar como…"
 
-#: src/window.rs:541
+#: src/window.rs:545
 msgid "Save attachment..."
 msgstr "Guardar el adjunto…"
 
-#: src/window.rs:555 src/window.rs:860
+#: src/window.rs:559 src/window.rs:864
 msgid "File Error"
 msgstr "Error de archivo"
 
-#: src/window.rs:577 src/window.rs:861
+#: src/window.rs:581 src/window.rs:865
 msgid "Failed to open file"
 msgstr "No se pudo abrir el archivo"
 
-#: src/window.rs:650
+#: src/window.rs:654
 msgid "Failed to open uri"
 msgstr "No se pudo abrir el URI"
 
-#: src/window.rs:707
+#: src/window.rs:711
 msgid "Mail Files"
 msgstr "Archivos de correo"
 
-#: src/window.rs:806
+#: src/window.rs:810
 msgid "Open Mail File"
 msgstr "Abrir un archivo de correo"
 
-#: src/window.rs:912
+#: src/window.rs:880
+msgid "This message is encrypted. MailViewer cannot show what is inside."
+msgstr "Este mensaje está cifrado. MailViewer no puede mostrar su contenido."
+
+#: src/window.rs:886
+msgid "This message is signed. MailViewer does not check the signature."
+msgstr "Este mensaje está firmado. MailViewer no comprueba la firma."
+
+#: src/window.rs:938
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} adjunto"
 msgstr[1] "{total} adjuntos"
 
 #. never shown
-#: src/window.rs:922
+#: src/window.rs:948
 msgid "No attachments"
 msgstr "Sin adjuntos"
 
-#: src/window.rs:936
+#: src/window.rs:962
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/window.rs:1007
+#: src/window.rs:1033
 msgid "Settings"
 msgstr "Configuración"
 
-#: src/window.rs:1008
+#: src/window.rs:1034
 msgid "Failed to get settings"
 msgstr "No se pudo obtener la configuración"
 

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 19:32+0200\n"
+"POT-Creation-Date: 2026-08-24 19:42+0200\n"
 "PO-Revision-Date: 2024-11-14 17:23+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -432,86 +432,94 @@ msgstr "Sujet:"
 msgid "Subject"
 msgstr "Sujet"
 
-#: src/window.blp:171
+#: src/window.blp:175
 msgid "HTML"
 msgstr "HTML"
 
-#: src/window.blp:181
+#: src/window.blp:185
 msgid "TEXT"
 msgstr "TEXTE"
 
-#: src/window.blp:234
+#: src/window.blp:238
 msgid "_Open..."
 msgstr "_Ouvrir..."
 
-#: src/window.blp:239
+#: src/window.blp:243
 msgid "Pr_int..."
 msgstr "_Imprimer..."
 
-#: src/window.blp:244
+#: src/window.blp:248
 msgid "_Preferences"
 msgstr "_Préférences"
 
-#: src/window.blp:249
+#: src/window.blp:253
 msgid "_Reset Zoom"
 msgstr "_Réinitialiser le zoom"
 
-#: src/window.blp:254
+#: src/window.blp:258
 msgid "_Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
-#: src/window.blp:259
+#: src/window.blp:263
 msgid "_About MailViewer"
 msgstr "_A propos de MailViewer"
 
-#: src/window.rs:476
+#: src/window.rs:480
 msgid "Save as..."
 msgstr "Enregister sous..."
 
-#: src/window.rs:541
+#: src/window.rs:545
 msgid "Save attachment..."
 msgstr "Enregister le fichier attaché..."
 
-#: src/window.rs:555 src/window.rs:860
+#: src/window.rs:559 src/window.rs:864
 msgid "File Error"
 msgstr "Erreur de fichier"
 
-#: src/window.rs:577 src/window.rs:861
+#: src/window.rs:581 src/window.rs:865
 msgid "Failed to open file"
 msgstr "Impossible d'ouvrir le fichier"
 
-#: src/window.rs:650
+#: src/window.rs:654
 msgid "Failed to open uri"
 msgstr "Impossible d'ouvrir le fichier"
 
-#: src/window.rs:707
+#: src/window.rs:711
 msgid "Mail Files"
 msgstr "Ouvrir un fichier"
 
-#: src/window.rs:806
+#: src/window.rs:810
 msgid "Open Mail File"
 msgstr "Ouvrir un message"
 
-#: src/window.rs:912
+#: src/window.rs:880
+msgid "This message is encrypted. MailViewer cannot show what is inside."
+msgstr ""
+
+#: src/window.rs:886
+msgid "This message is signed. MailViewer does not check the signature."
+msgstr ""
+
+#: src/window.rs:938
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} fichier attaché"
 msgstr[1] "{total} fichiers attachés"
 
 #. never shown
-#: src/window.rs:922
+#: src/window.rs:948
 msgid "No attachments"
 msgstr "Aucun fichier attaché"
 
-#: src/window.rs:936
+#: src/window.rs:962
 msgid "Close"
 msgstr "Fermer"
 
-#: src/window.rs:1007
+#: src/window.rs:1033
 msgid "Settings"
 msgstr "Préférences"
 
-#: src/window.rs:1008
+#: src/window.rs:1034
 msgid "Failed to get settings"
 msgstr "Impossible de trouver les préférences"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 19:32+0200\n"
+"POT-Creation-Date: 2026-08-24 19:42+0200\n"
 "PO-Revision-Date: 2025-05-07 22:22+0100\n"
 "Last-Translator: Albano Battistella <albanobattistella@gmail.com>\n"
 "Language-Team: Italian <LL@li.org>\n"
@@ -427,86 +427,94 @@ msgstr "Soggetto:"
 msgid "Subject"
 msgstr "Soggetto:"
 
-#: src/window.blp:171
+#: src/window.blp:175
 msgid "HTML"
 msgstr "HTML"
 
-#: src/window.blp:181
+#: src/window.blp:185
 msgid "TEXT"
 msgstr "TESTO"
 
-#: src/window.blp:234
+#: src/window.blp:238
 msgid "_Open..."
 msgstr "_Apri..."
 
-#: src/window.blp:239
+#: src/window.blp:243
 msgid "Pr_int..."
 msgstr "S_tampa..."
 
-#: src/window.blp:244
+#: src/window.blp:248
 msgid "_Preferences"
 msgstr "_Preferenze"
 
-#: src/window.blp:249
+#: src/window.blp:253
 msgid "_Reset Zoom"
 msgstr "_Reimposta zoom"
 
-#: src/window.blp:254
+#: src/window.blp:258
 msgid "_Keyboard Shortcuts"
 msgstr "_Scorciatoie da tastiera"
 
-#: src/window.blp:259
+#: src/window.blp:263
 msgid "_About MailViewer"
 msgstr "_Informazioni su MailViewer"
 
-#: src/window.rs:476
+#: src/window.rs:480
 msgid "Save as..."
 msgstr "Salva con nome..."
 
-#: src/window.rs:541
+#: src/window.rs:545
 msgid "Save attachment..."
 msgstr "Salva allegato..."
 
-#: src/window.rs:555 src/window.rs:860
+#: src/window.rs:559 src/window.rs:864
 msgid "File Error"
 msgstr "Errore file"
 
-#: src/window.rs:577 src/window.rs:861
+#: src/window.rs:581 src/window.rs:865
 msgid "Failed to open file"
 msgstr "Impossibile aprire il file"
 
-#: src/window.rs:650
+#: src/window.rs:654
 msgid "Failed to open uri"
 msgstr "Impossibile aprire il file"
 
-#: src/window.rs:707
+#: src/window.rs:711
 msgid "Mail Files"
 msgstr "Apri file di posta"
 
-#: src/window.rs:806
+#: src/window.rs:810
 msgid "Open Mail File"
 msgstr "Apri file di posta"
 
-#: src/window.rs:912
+#: src/window.rs:880
+msgid "This message is encrypted. MailViewer cannot show what is inside."
+msgstr ""
+
+#: src/window.rs:886
+msgid "This message is signed. MailViewer does not check the signature."
+msgstr ""
+
+#: src/window.rs:938
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} allegato"
 msgstr[1] "{total} allegati"
 
 #. never shown
-#: src/window.rs:922
+#: src/window.rs:948
 msgid "No attachments"
 msgstr "Nessun allegato"
 
-#: src/window.rs:936
+#: src/window.rs:962
 msgid "Close"
 msgstr "Chiudi"
 
-#: src/window.rs:1007
+#: src/window.rs:1033
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/window.rs:1008
+#: src/window.rs:1034
 msgid "Failed to get settings"
 msgstr "Impossibile ottenere le impostazioni"
 

--- a/po/mailviewer.pot
+++ b/po/mailviewer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 19:32+0200\n"
+"POT-Creation-Date: 2026-08-24 19:42+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -420,85 +420,93 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: src/window.blp:171
+#: src/window.blp:175
 msgid "HTML"
 msgstr ""
 
-#: src/window.blp:181
+#: src/window.blp:185
 msgid "TEXT"
 msgstr ""
 
-#: src/window.blp:234
+#: src/window.blp:238
 msgid "_Open..."
 msgstr ""
 
-#: src/window.blp:239
+#: src/window.blp:243
 msgid "Pr_int..."
 msgstr ""
 
-#: src/window.blp:244
+#: src/window.blp:248
 msgid "_Preferences"
 msgstr ""
 
-#: src/window.blp:249
+#: src/window.blp:253
 msgid "_Reset Zoom"
 msgstr ""
 
-#: src/window.blp:254
+#: src/window.blp:258
 msgid "_Keyboard Shortcuts"
 msgstr ""
 
-#: src/window.blp:259
+#: src/window.blp:263
 msgid "_About MailViewer"
 msgstr ""
 
-#: src/window.rs:476
+#: src/window.rs:480
 msgid "Save as..."
 msgstr ""
 
-#: src/window.rs:541
+#: src/window.rs:545
 msgid "Save attachment..."
 msgstr ""
 
-#: src/window.rs:555 src/window.rs:860
+#: src/window.rs:559 src/window.rs:864
 msgid "File Error"
 msgstr ""
 
-#: src/window.rs:577 src/window.rs:861
+#: src/window.rs:581 src/window.rs:865
 msgid "Failed to open file"
 msgstr ""
 
-#: src/window.rs:650
+#: src/window.rs:654
 msgid "Failed to open uri"
 msgstr ""
 
-#: src/window.rs:707
+#: src/window.rs:711
 msgid "Mail Files"
 msgstr ""
 
-#: src/window.rs:806
+#: src/window.rs:810
 msgid "Open Mail File"
 msgstr ""
 
-#: src/window.rs:912
+#: src/window.rs:880
+msgid "This message is encrypted. MailViewer cannot show what is inside."
+msgstr ""
+
+#: src/window.rs:886
+msgid "This message is signed. MailViewer does not check the signature."
+msgstr ""
+
+#: src/window.rs:938
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] ""
 msgstr[1] ""
 
 #. never shown
-#: src/window.rs:922
+#: src/window.rs:948
 msgid "No attachments"
 msgstr ""
 
-#: src/window.rs:936
+#: src/window.rs:962
 msgid "Close"
 msgstr ""
 
-#: src/window.rs:1007
+#: src/window.rs:1033
 msgid "Settings"
 msgstr ""
 
-#: src/window.rs:1008
+#: src/window.rs:1034
 msgid "Failed to get settings"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mailviewer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 19:32+0200\n"
+"POT-Creation-Date: 2026-08-24 19:42+0200\n"
 "PO-Revision-Date: 2025-11-12 20:10+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -429,86 +429,94 @@ msgstr "Onderwerp:"
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: src/window.blp:171
+#: src/window.blp:175
 msgid "HTML"
 msgstr "Html"
 
-#: src/window.blp:181
+#: src/window.blp:185
 msgid "TEXT"
 msgstr "Tekst"
 
-#: src/window.blp:234
+#: src/window.blp:238
 msgid "_Open..."
 msgstr "_Openen…"
 
-#: src/window.blp:239
+#: src/window.blp:243
 msgid "Pr_int..."
 msgstr "Af_drukken…"
 
-#: src/window.blp:244
+#: src/window.blp:248
 msgid "_Preferences"
 msgstr "_Voorkeuren"
 
-#: src/window.blp:249
+#: src/window.blp:253
 msgid "_Reset Zoom"
 msgstr "Oo_rspronkelijk zoomniveau"
 
-#: src/window.blp:254
+#: src/window.blp:258
 msgid "_Keyboard Shortcuts"
 msgstr "_Sneltoetsen"
 
-#: src/window.blp:259
+#: src/window.blp:263
 msgid "_About MailViewer"
 msgstr "Over MailWeerg_ave"
 
-#: src/window.rs:476
+#: src/window.rs:480
 msgid "Save as..."
 msgstr "Opslaan als…"
 
-#: src/window.rs:541
+#: src/window.rs:545
 msgid "Save attachment..."
 msgstr "Bijlage opslaan…"
 
-#: src/window.rs:555 src/window.rs:860
+#: src/window.rs:559 src/window.rs:864
 msgid "File Error"
 msgstr "Bestandsfout"
 
-#: src/window.rs:577 src/window.rs:861
+#: src/window.rs:581 src/window.rs:865
 msgid "Failed to open file"
 msgstr "Kan de URI niet openen"
 
-#: src/window.rs:650
+#: src/window.rs:654
 msgid "Failed to open uri"
 msgstr "Kan de URI niet openen"
 
-#: src/window.rs:707
+#: src/window.rs:711
 msgid "Mail Files"
 msgstr "Mailbestanden"
 
-#: src/window.rs:806
+#: src/window.rs:810
 msgid "Open Mail File"
 msgstr "Mailbestand openen"
 
-#: src/window.rs:912
+#: src/window.rs:880
+msgid "This message is encrypted. MailViewer cannot show what is inside."
+msgstr ""
+
+#: src/window.rs:886
+msgid "This message is signed. MailViewer does not check the signature."
+msgstr ""
+
+#: src/window.rs:938
 msgid "{total} attachment"
 msgid_plural "{total} attachments"
 msgstr[0] "{total} bijlage"
 msgstr[1] "{total} bijlagen"
 
 #. never shown
-#: src/window.rs:922
+#: src/window.rs:948
 msgid "No attachments"
 msgstr "Er zijn geen bijlagen"
 
-#: src/window.rs:936
+#: src/window.rs:962
 msgid "Close"
 msgstr "Sluiten"
 
-#: src/window.rs:1007
+#: src/window.rs:1033
 msgid "Settings"
 msgstr "Voorkeuren"
 
-#: src/window.rs:1008
+#: src/window.rs:1034
 msgid "Failed to get settings"
 msgstr "De voorkeuren zijn niet beschikbaar"
 

--- a/src/mailservice.rs
+++ b/src/mailservice.rs
@@ -20,7 +20,7 @@
 use std::cell::RefCell;
 
 use mailviewer_core::message::attachment::Attachment;
-use mailviewer_core::message::message::{Message, MessageParser};
+use mailviewer_core::message::message::{Message, MessageParser, Protection};
 
 use crate::config::VERSION;
 use crate::gio::prelude::*;
@@ -119,6 +119,13 @@ impl MailService {
       return parser.body_html();
     }
     None
+  }
+
+  pub fn protection(&self) -> Protection {
+    if let Some(parser) = self.parser.borrow().as_ref() {
+      return parser.protection();
+    }
+    Protection::None
   }
 
   pub fn attachments(&self) -> Vec<Attachment> {

--- a/src/window.blp
+++ b/src/window.blp
@@ -153,6 +153,10 @@ template $MailViewerWindow: Adw.ApplicationWindow {
           }
         }
 
+        Adw.Banner protection_banner {
+          revealed: false;
+        }
+
         SearchBar search_bar {
           visible: bind show_text.active inverted;
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -26,6 +26,7 @@ use gettextrs::{gettext, ngettext};
 use gtk4::{gio, glib, template_callbacks};
 use mailviewer_core::html::Html;
 use mailviewer_core::message::attachment::Attachment;
+use mailviewer_core::message::message::Protection;
 use mailviewer_core::message::message::MessageParser;
 use mailviewer_core::utils;
 use webkit6::prelude::{PolicyDecisionExt, WebViewExt};
@@ -90,6 +91,8 @@ mod imp {
     #[template_child]
     pub attachments_clamp: TemplateChild<adw::Clamp>,
     #[template_child]
+    pub protection_banner: TemplateChild<adw::Banner>,
+    #[template_child]
     pub search_bar: TemplateChild<gtk4::SearchBar>,
     #[template_child]
     pub search_entry: TemplateChild<gtk4::SearchEntry>,
@@ -130,6 +133,7 @@ mod imp {
         stack: TemplateChild::default(),
         pull_label: TemplateChild::default(),
         attachments_clamp: TemplateChild::default(),
+        protection_banner: TemplateChild::default(),
         search_bar: TemplateChild::default(),
         search_entry: TemplateChild::default(),
         content_box: TemplateChild::default(),
@@ -866,6 +870,27 @@ impl MailViewerWindow {
     self.imp().content_box.get().set_sensitive(true);
   }
 
+  /// Says what the message claims about itself. Nothing is checked and nothing
+  /// is decrypted, so the wording stays away from promising either.
+  fn show_protection(&self, protection: Protection) {
+    let banner = &self.imp().protection_banner;
+    match protection {
+      Protection::Encrypted => {
+        banner.set_title(&gettext(
+          "This message is encrypted. MailViewer cannot show what is inside.",
+        ));
+        banner.set_revealed(true);
+      }
+      Protection::Signed => {
+        banner.set_title(&gettext(
+          "This message is signed. MailViewer does not check the signature.",
+        ));
+        banner.set_revealed(true);
+      }
+      Protection::None => banner.set_revealed(false),
+    }
+  }
+
   pub fn display_message(&self) {
     log::debug!("display_eml()");
     let imp = self.imp();
@@ -874,6 +899,7 @@ impl MailViewerWindow {
     imp.date.set_text(imp.service.date().as_str());
     imp.to.set_text(imp.service.to().as_str());
     imp.subject.set_text(imp.service.subject().as_str());
+    self.show_protection(imp.service.protection());
 
     let mut has_text: bool = false;
     let mut has_html: bool = false;


### PR DESCRIPTION
Step 1 of #52, the one you pointed at. No keys, no permissions, no crypto.

An encrypted message renders as an empty body with `encrypted.asc` next to it, and nothing tells the reader why. A banner above the message now says what the message claims about itself:

- encrypted: "This message is encrypted. MailViewer cannot show what is inside."
- signed: "This message is signed. MailViewer does not check the signature."

Nothing is checked and nothing is decrypted, so the wording promises neither.

Needs alescdb/mailviewer-core#3, which is where the detection lives. The `Cargo.lock` bump comes once that lands, tell me if you would rather have it in this branch.